### PR TITLE
added missing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A collection of View Components for rendering form fields in the Perique Framewo
 [![WordPress 6.8 Test Suite [PHP8.0-8.4]](https://github.com/Pink-Crab/Perique-Form-Components/actions/workflows/WP_6_8.yaml/badge.svg)](https://github.com/Pink-Crab/Perique-Form-Components/actions/workflows/WP_6_8.yaml)
 [![WordPress 6.9 Test Suite [PHP8.0-8.4]](https://github.com/Pink-Crab/Perique-Form-Components/actions/workflows/WP_6_9.yaml/badge.svg)](https://github.com/Pink-Crab/Perique-Form-Components/actions/workflows/WP_6_9.yaml)
 [![E2E Tests (Playwright)](https://github.com/Pink-Crab/Perique-Form-Components/actions/workflows/E2E.yaml/badge.svg)](https://github.com/Pink-Crab/Perique-Form-Components/actions/workflows/E2E.yaml)
+[![codecov](https://codecov.io/gh/Pink-Crab/Perique-Form-Components/graph/badge.svg?token=hdrrvng8pv)](https://codecov.io/gh/Pink-Crab/Perique-Form-Components)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Pink-Crab/Perique-Form-Components/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Pink-Crab/Perique-Form-Components/?branch=master)
 
 ****

--- a/tests/Fixtures/Mock_Objects/Element_With_Notification_Only.php
+++ b/tests/Fixtures/Mock_Objects/Element_With_Notification_Only.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Stub element that uses the Notification trait but NOT Form_Style.
+ * Used to test the Notification_Component guard clause.
+ *
+ * Implements Element directly (not extending Field which has Form_Style).
+ */
+
+namespace PinkCrab\Form_Components\Tests\Fixtures\Mock_Objects;
+
+use PinkCrab\Form_Components\Style\Style;
+use PinkCrab\Form_Components\Element\Element;
+use PinkCrab\Form_Components\Element\Field_Traits\Wrapper_Attributes;
+use PinkCrab\Form_Components\Element\Field\Attribute\Notification;
+
+class Element_With_Notification_Only implements Element {
+
+	use Wrapper_Attributes, Notification;
+
+	/** @var string */
+	protected $name;
+
+	/** @var array<string, mixed> */
+	protected $attributes = array();
+
+	public function __construct( string $name ) {
+		$this->name = $name;
+	}
+
+	public function get_name(): string {
+		return $this->name;
+	}
+
+	public function get_type(): string {
+		return 'mock';
+	}
+
+	// Satisfy the Notification trait's abstract methods
+	public function get_style(): Style {
+		return new \PinkCrab\Form_Components\Style\Default_Style();
+	}
+
+	public function add_class( string $class_name ): Element {
+		return $this;
+	}
+
+	public function get_attribute( string $attribute ) {
+		return $this->attributes[ $attribute ] ?? null;
+	}
+
+	public function has_attributes(): bool {
+		return ! empty( $this->attributes );
+	}
+}

--- a/tests/Fixtures/Mock_Objects/Validator_Stub.php
+++ b/tests/Fixtures/Mock_Objects/Validator_Stub.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Stub for Respect\Validation\Validator used in tests.
+ *
+ * The real package is not installed as a dependency, so we provide
+ * a minimal stub that satisfies the type hints in the Validation trait.
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Respect\Validation;
+
+if ( ! interface_exists( 'Respect\Validation\Validatable' ) ) {
+	interface Validatable {
+		/**
+		 * @param mixed $input
+		 * @return bool
+		 */
+		public function validate( $input ): bool;
+	}
+}
+
+if ( ! class_exists( 'Respect\Validation\Validator' ) ) {
+	class Validator implements Validatable {
+		/**
+		 * @param mixed $input
+		 * @return bool
+		 */
+		public function validate( $input ): bool {
+			return true;
+		}
+	}
+}

--- a/tests/Unit/Component/Test_Component_Factory.php
+++ b/tests/Unit/Component/Test_Component_Factory.php
@@ -12,10 +12,35 @@ declare(strict_types=1);
 namespace PinkCrab\Form_Components\Tests\Unit\Component;
 
 use WP_UnitTestCase;
+use PinkCrab\Form_Components\Element\Form;
+use PinkCrab\Form_Components\Element\Nonce;
+use PinkCrab\Form_Components\Element\Group;
+use PinkCrab\Form_Components\Element\Button;
+use PinkCrab\Form_Components\Element\Raw_HTML;
+use PinkCrab\Form_Components\Element\Fieldset;
+use PinkCrab\Form_Components\Element\Field\Select;
+use PinkCrab\Form_Components\Element\Field\Textarea;
 use PinkCrab\Form_Components\Element\Field\Input\Text;
+use PinkCrab\Form_Components\Element\Field\Input\Radio;
+use PinkCrab\Form_Components\Element\Field\Group\Radio_Group;
+use PinkCrab\Form_Components\Element\Field\Group\Checkbox_Group;
 use PinkCrab\Form_Components\Component\Component_Factory;
 use PinkCrab\Form_Components\Component\Field\Input_Component;
+use PinkCrab\Form_Components\Component\Field\Button_Component;
+use PinkCrab\Form_Components\Component\Field\Select_Component;
+use PinkCrab\Form_Components\Component\Field\Raw_HTML_Component;
+use PinkCrab\Form_Components\Component\Field\Textarea_Component;
+use PinkCrab\Form_Components\Component\Field\Radio_Group_Component;
+use PinkCrab\Form_Components\Component\Field\Checkbox_Group_Component;
+use PinkCrab\Form_Components\Component\Form\Form_Component;
+use PinkCrab\Form_Components\Component\Form\Group_Component;
+use PinkCrab\Form_Components\Component\Form\Fieldset_Component;
+use PinkCrab\Form_Components\Component\Partial\Nonce_Component;
 
+/**
+ * @group unit
+ * @group component
+ */
 class Test_Component_Factory extends WP_UnitTestCase {
 
 	/** @testdox It should be possible to get an instance of the component factory using a static constructor */
@@ -26,11 +51,202 @@ class Test_Component_Factory extends WP_UnitTestCase {
 	/** @testdox It should be possible to create an Input component from an Input field. */
 	public function test_create_input(): void {
 		$field  = new Text( 'test' );
-		
+
         // Using from_field() method.
 		$this->assertInstanceOf( Input_Component::class, Component_Factory::instance()->from_field( $field ) );
 
         // Using from_element() method.
         $this->assertInstanceOf( Input_Component::class, Component_Factory::instance()->from_element( $field ) );
+	}
+
+	/** @testdox It should be possible to create a Checkbox_Group component */
+	public function test_create_checkbox_group(): void {
+		$group = new Checkbox_Group( 'test_group' );
+		$component = Component_Factory::instance()->from_checkbox_group( $group );
+		$this->assertInstanceOf( Checkbox_Group_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Checkbox_Group */
+	public function test_from_element_checkbox_group(): void {
+		$group = new Checkbox_Group( 'test_group' );
+		$component = Component_Factory::instance()->from_element( $group );
+		$this->assertInstanceOf( Checkbox_Group_Component::class, $component );
+	}
+
+	/** @testdox It should be possible to create a Radio_Group component */
+	public function test_create_radio_group(): void {
+		$group = new Radio_Group( 'test_group' );
+		$component = Component_Factory::instance()->from_radio_group( $group );
+		$this->assertInstanceOf( Radio_Group_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Radio_Group */
+	public function test_from_element_radio_group(): void {
+		$group = new Radio_Group( 'test_group' );
+		$component = Component_Factory::instance()->from_element( $group );
+		$this->assertInstanceOf( Radio_Group_Component::class, $component );
+	}
+
+	/** @testdox It should be possible to create a Select component */
+	public function test_create_select(): void {
+		$select = new Select( 'test_select' );
+		$component = Component_Factory::instance()->from_select( $select );
+		$this->assertInstanceOf( Select_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Select */
+	public function test_from_element_select(): void {
+		$select = new Select( 'test_select' );
+		$component = Component_Factory::instance()->from_element( $select );
+		$this->assertInstanceOf( Select_Component::class, $component );
+	}
+
+	/** @testdox It should be possible to create a Textarea component */
+	public function test_create_textarea(): void {
+		$textarea = new Textarea( 'test_textarea' );
+		$component = Component_Factory::instance()->from_textarea( $textarea );
+		$this->assertInstanceOf( Textarea_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Textarea */
+	public function test_from_element_textarea(): void {
+		$textarea = new Textarea( 'test_textarea' );
+		$component = Component_Factory::instance()->from_element( $textarea );
+		$this->assertInstanceOf( Textarea_Component::class, $component );
+	}
+
+	/** @testdox It should be possible to create a Button component */
+	public function test_create_button(): void {
+		$button = new Button( 'test_button' );
+		$component = Component_Factory::instance()->from_button( $button );
+		$this->assertInstanceOf( Button_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Button */
+	public function test_from_element_button(): void {
+		$button = new Button( 'test_button' );
+		$component = Component_Factory::instance()->from_element( $button );
+		$this->assertInstanceOf( Button_Component::class, $component );
+	}
+
+	/** @testdox It should be possible to create a Raw_HTML component */
+	public function test_create_raw_html(): void {
+		$html = new Raw_HTML( 'test_html' );
+		$component = Component_Factory::instance()->from_html( $html );
+		$this->assertInstanceOf( Raw_HTML_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Raw_HTML */
+	public function test_from_element_raw_html(): void {
+		$html = new Raw_HTML( 'test_html' );
+		$component = Component_Factory::instance()->from_element( $html );
+		$this->assertInstanceOf( Raw_HTML_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Nonce */
+	public function test_from_element_nonce(): void {
+		$nonce = new Nonce( 'test_action', 'test_nonce' );
+		$component = Component_Factory::instance()->from_element( $nonce );
+		$this->assertInstanceOf( Nonce_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Form */
+	public function test_from_element_form(): void {
+		$form = new Form( 'test_form' );
+		$component = Component_Factory::instance()->from_element( $form );
+		$this->assertInstanceOf( Form_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Fieldset */
+	public function test_from_element_fieldset(): void {
+		$fieldset = new Fieldset( 'test_fieldset' );
+		$component = Component_Factory::instance()->from_element( $fieldset );
+		$this->assertInstanceOf( Fieldset_Component::class, $component );
+	}
+
+	/** @testdox It should be possible to create a Group component */
+	public function test_create_group(): void {
+		$group = new Group( 'test_group' );
+		$group->fields( new Text( 'field1' ) );
+		$component = Component_Factory::instance()->from_group( $group );
+		$this->assertInstanceOf( Group_Component::class, $component );
+	}
+
+	/** @testdox from_element should correctly dispatch Group */
+	public function test_from_element_group(): void {
+		$group = new Group( 'test_group' );
+		$group->fields( new Text( 'field1' ) );
+		$component = Component_Factory::instance()->from_element( $group );
+		$this->assertInstanceOf( Group_Component::class, $component );
+	}
+
+	/** @testdox Group should auto-add wrapper id if not set */
+	public function test_group_auto_wrapper_id(): void {
+		$group = new Group( 'my_group' );
+		$group->fields( new Text( 'field1' ) );
+
+		// Remove the auto-set id via reflection so from_group adds its own
+		$group->remove_wrapper_attribute( 'id' );
+
+		$component  = Component_Factory::instance()->from_group( $group );
+		$reflection = new \ReflectionClass( $component );
+
+		$attr_prop = $reflection->getProperty( 'attributes' );
+		$attr_prop->setAccessible( true );
+		$this->assertStringContainsString( 'field_my_group_wrapper', $attr_prop->getValue( $component ) );
+	}
+
+	/** @testdox Group with existing wrapper id should keep it */
+	public function test_group_existing_wrapper_id(): void {
+		$group = new Group( 'my_group' );
+		$group->wrapper_attribute( 'id', 'custom_id' );
+		$group->fields( new Text( 'field1' ) );
+		$component  = Component_Factory::instance()->from_group( $group );
+		$reflection = new \ReflectionClass( $component );
+
+		$attr_prop = $reflection->getProperty( 'attributes' );
+		$attr_prop->setAccessible( true );
+		$this->assertStringContainsString( 'custom_id', $attr_prop->getValue( $component ) );
+		$this->assertStringNotContainsString( 'field_my_group', $attr_prop->getValue( $component ) );
+	}
+
+	/** @testdox Group with before/after content should pass it to the component */
+	public function test_group_before_after(): void {
+		$group = new Group( 'my_group' );
+		$group->before( '<h3>Section</h3>' );
+		$group->after( '<hr>' );
+		$group->fields( new Text( 'field1' ) );
+		$component  = Component_Factory::instance()->from_group( $group );
+		$reflection = new \ReflectionClass( $component );
+
+		$before_prop = $reflection->getProperty( 'before' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '<h3>Section</h3>', $before_prop->getValue( $component ) );
+
+		$after_prop = $reflection->getProperty( 'after' );
+		$after_prop->setAccessible( true );
+		$this->assertEquals( '<hr>', $after_prop->getValue( $component ) );
+	}
+
+	/** @testdox from_elements should convert an array of elements to components */
+	public function test_from_elements(): void {
+		$elements = array(
+			new Text( 'text_field' ),
+			new Select( 'select_field' ),
+			new Textarea( 'textarea_field' ),
+		);
+		$components = Component_Factory::instance()->from_elements( $elements );
+		$this->assertCount( 3, $components );
+		$this->assertInstanceOf( Input_Component::class, $components[0] );
+		$this->assertInstanceOf( Select_Component::class, $components[1] );
+		$this->assertInstanceOf( Textarea_Component::class, $components[2] );
+	}
+
+	/** @testdox from_element should throw InvalidArgumentException for unknown element types */
+	public function test_from_element_throws_for_unknown(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$unknown = $this->createMock( \PinkCrab\Form_Components\Element\Element::class );
+		$unknown->method( 'get_type' )->willReturn( 'unknown' );
+		Component_Factory::instance()->from_element( $unknown );
 	}
 }

--- a/tests/Unit/Component/Test_Components.php
+++ b/tests/Unit/Component/Test_Components.php
@@ -1,0 +1,624 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for individual Component classes that have 0% coverage.
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Component;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Element\Form;
+use PinkCrab\Form_Components\Element\Button;
+use PinkCrab\Form_Components\Element\Raw_HTML;
+use PinkCrab\Form_Components\Element\Fieldset;
+use PinkCrab\Form_Components\Element\Field\Select;
+use PinkCrab\Form_Components\Element\Field\Textarea;
+use PinkCrab\Form_Components\Element\Field\Input\Text;
+use PinkCrab\Form_Components\Element\Field\Group\Checkbox_Group;
+use PinkCrab\Form_Components\Element\Field\Group\Radio_Group;
+use PinkCrab\Form_Components\Component\Field\Button_Component;
+use PinkCrab\Form_Components\Component\Field\Raw_HTML_Component;
+use PinkCrab\Form_Components\Component\Field\Select_Component;
+use PinkCrab\Form_Components\Component\Field\Textarea_Component;
+use PinkCrab\Form_Components\Component\Field\Checkbox_Group_Component;
+use PinkCrab\Form_Components\Component\Field\Radio_Group_Component;
+use PinkCrab\Form_Components\Component\Field\Datalist_Component;
+use PinkCrab\Form_Components\Component\Field\Label_Component;
+use PinkCrab\Form_Components\Component\Field\Notification_Component;
+use PinkCrab\Form_Components\Component\Form\Form_Component;
+use PinkCrab\Form_Components\Component\Form\Fieldset_Component;
+use PinkCrab\Form_Components\Component\Form\Group_Component;
+use PinkCrab\Form_Components\Component\Partial\Field_Wrapper_End;
+use PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start;
+use PinkCrab\Form_Components\Component\Field\Input_Component;
+use PinkCrab\Perique\Services\View\Component\Component;
+
+/**
+ * @group unit
+ * @group component
+ */
+class Test_Components extends WP_UnitTestCase {
+
+	####################################################################
+	######                  DATALIST COMPONENT                   ######
+	####################################################################
+
+	/** @testdox Datalist_Component should be constructable with an id and items */
+	public function test_datalist_component_construct(): void {
+		$component = new Datalist_Component( 'my_list', array( 'opt1' => 'Label 1', 'opt2' => 'Label 2' ) );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	/** @testdox Datalist_Component should store its id and items */
+	public function test_datalist_component_properties(): void {
+		$items     = array( 'value1' => 'Label 1', 'value2' => null );
+		$component = new Datalist_Component( 'test_list', $items );
+
+		// Access via reflection since properties are protected
+		$reflection = new \ReflectionClass( $component );
+
+		$id_prop = $reflection->getProperty( 'id' );
+		$id_prop->setAccessible( true );
+		$this->assertEquals( 'test_list', $id_prop->getValue( $component ) );
+
+		$items_prop = $reflection->getProperty( 'items' );
+		$items_prop->setAccessible( true );
+		$this->assertEquals( $items, $items_prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######                   LABEL COMPONENT                     ######
+	####################################################################
+
+	/** @testdox Label_Component should be constructable with a label and for_name */
+	public function test_label_component_construct(): void {
+		$component = new Label_Component( 'My Label', 'field_name' );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	/** @testdox Label_Component should store its properties */
+	public function test_label_component_properties(): void {
+		$component  = new Label_Component( 'Email Address', 'email_field', 'custom-class' );
+		$reflection = new \ReflectionClass( $component );
+
+		$label_prop = $reflection->getProperty( 'label' );
+		$label_prop->setAccessible( true );
+		$this->assertEquals( 'Email Address', $label_prop->getValue( $component ) );
+
+		$for_prop = $reflection->getProperty( 'for_name' );
+		$for_prop->setAccessible( true );
+		$this->assertEquals( 'email_field', $for_prop->getValue( $component ) );
+
+		$class_prop = $reflection->getProperty( 'label_class' );
+		$class_prop->setAccessible( true );
+		$this->assertEquals( 'custom-class', $class_prop->getValue( $component ) );
+	}
+
+	/** @testdox Label_Component label_class should default to empty string */
+	public function test_label_component_default_class(): void {
+		$component  = new Label_Component( 'My Label', 'field_name' );
+		$reflection = new \ReflectionClass( $component );
+
+		$class_prop = $reflection->getProperty( 'label_class' );
+		$class_prop->setAccessible( true );
+		$this->assertEquals( '', $class_prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######               NOTIFICATION COMPONENT                  ######
+	####################################################################
+
+	/** @testdox Notification_Component should be constructable from a field with notification */
+	public function test_notification_component_construct(): void {
+		$text = new Text( 'test' );
+		$text->error_notification( 'This field is required' );
+		$component = new Notification_Component( $text );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	/** @testdox Notification_Component should store notification and wrapper class */
+	public function test_notification_component_properties(): void {
+		$text = new Text( 'test' );
+		$text->warning_notification( 'Please check this' );
+		$component  = new Notification_Component( $text );
+		$reflection = new \ReflectionClass( $component );
+
+		$notif_prop = $reflection->getProperty( 'notification' );
+		$notif_prop->setAccessible( true );
+		$this->assertEquals( 'Please check this', $notif_prop->getValue( $component ) );
+
+		$class_prop = $reflection->getProperty( 'wrapper_class' );
+		$class_prop->setAccessible( true );
+		$this->assertStringContainsString( 'warning', $class_prop->getValue( $component ) );
+	}
+
+	/** @testdox Notification_Component should throw for element without Notification trait */
+	public function test_notification_component_throws_without_notification_trait(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Element must implement Notification' );
+
+		// Use a mock of the Element interface which won't have the Notification trait
+		$element = $this->createMock( \PinkCrab\Form_Components\Element\Element::class );
+		new Notification_Component( $element );
+	}
+
+	/** @testdox Notification_Component should throw for element with Notification but without Form_Style trait */
+	public function test_notification_component_throws_without_form_style(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Element must have a style' );
+
+		// Create an element that uses Notification but not Form_Style
+		$element = new \PinkCrab\Form_Components\Tests\Fixtures\Mock_Objects\Element_With_Notification_Only( 'test' );
+		new Notification_Component( $element );
+	}
+
+	####################################################################
+	######                  GROUP COMPONENT                      ######
+	####################################################################
+
+	/** @testdox Group_Component should be constructable */
+	public function test_group_component_construct(): void {
+		$component = new Group_Component( array(), 'id="test"' );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	/** @testdox Group_Component should store its properties */
+	public function test_group_component_properties(): void {
+		$child      = new Input_Component( new Text( 'field1' ) );
+		$component  = new Group_Component( array( $child ), 'id="group1" class="wrapper"', '<h3>Before</h3>', '<p>After</p>' );
+		$reflection = new \ReflectionClass( $component );
+
+		$comp_prop = $reflection->getProperty( 'components' );
+		$comp_prop->setAccessible( true );
+		$this->assertCount( 1, $comp_prop->getValue( $component ) );
+
+		$attr_prop = $reflection->getProperty( 'attributes' );
+		$attr_prop->setAccessible( true );
+		$this->assertEquals( 'id="group1" class="wrapper"', $attr_prop->getValue( $component ) );
+
+		$before_prop = $reflection->getProperty( 'before' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '<h3>Before</h3>', $before_prop->getValue( $component ) );
+
+		$after_prop = $reflection->getProperty( 'after' );
+		$after_prop->setAccessible( true );
+		$this->assertEquals( '<p>After</p>', $after_prop->getValue( $component ) );
+	}
+
+	/** @testdox Group_Component before/after should default to empty strings */
+	public function test_group_component_defaults(): void {
+		$component  = new Group_Component( array(), '' );
+		$reflection = new \ReflectionClass( $component );
+
+		$before_prop = $reflection->getProperty( 'before' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '', $before_prop->getValue( $component ) );
+
+		$after_prop = $reflection->getProperty( 'after' );
+		$after_prop->setAccessible( true );
+		$this->assertEquals( '', $after_prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######              FIELD WRAPPER END COMPONENT               ######
+	####################################################################
+
+	/** @testdox Field_Wrapper_End should be constructable */
+	public function test_field_wrapper_end_construct(): void {
+		$component = new Field_Wrapper_End( 'after content' );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	/** @testdox Field_Wrapper_End should store after_field */
+	public function test_field_wrapper_end_properties(): void {
+		$component  = new Field_Wrapper_End( '<p>After</p>' );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'after_field' );
+		$prop->setAccessible( true );
+		$this->assertEquals( '<p>After</p>', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Field_Wrapper_End should default to empty string for null */
+	public function test_field_wrapper_end_null(): void {
+		$component  = new Field_Wrapper_End( null );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'after_field' );
+		$prop->setAccessible( true );
+		$this->assertEquals( '', $prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######            FIELD WRAPPER START COMPONENT               ######
+	####################################################################
+
+	/** @testdox Field_Wrapper_Start should be constructable */
+	public function test_field_wrapper_start_construct(): void {
+		$component = new Field_Wrapper_Start( 'class="wrapper"', 'before content' );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	/** @testdox Field_Wrapper_Start should store its properties */
+	public function test_field_wrapper_start_properties(): void {
+		$component  = new Field_Wrapper_Start( 'id="wrapper" class="test"', '<h3>Before</h3>' );
+		$reflection = new \ReflectionClass( $component );
+
+		$attr_prop = $reflection->getProperty( 'wrapper_attributes' );
+		$attr_prop->setAccessible( true );
+		$this->assertEquals( 'id="wrapper" class="test"', $attr_prop->getValue( $component ) );
+
+		$before_prop = $reflection->getProperty( 'before_field' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '<h3>Before</h3>', $before_prop->getValue( $component ) );
+	}
+
+	/** @testdox Field_Wrapper_Start should default before_field to empty string for null */
+	public function test_field_wrapper_start_null_before(): void {
+		$component  = new Field_Wrapper_Start( 'class="test"', null );
+		$reflection = new \ReflectionClass( $component );
+
+		$before_prop = $reflection->getProperty( 'before_field' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '', $before_prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######                  FORM COMPONENT                       ######
+	####################################################################
+
+	/** @testdox Form_Component should include action attribute when set */
+	public function test_form_component_with_action(): void {
+		$form = new Form( 'test_form' );
+		$form->action( '/submit' );
+		$form->fields( new Text( 'name' ) );
+		$component  = new Form_Component( $form );
+		$reflection = new \ReflectionClass( $component );
+
+		$attr_prop = $reflection->getProperty( 'form_attributes' );
+		$attr_prop->setAccessible( true );
+		$this->assertStringContainsString( 'action=', $attr_prop->getValue( $component ) );
+	}
+
+	/** @testdox Form_Component should include enctype attribute when set */
+	public function test_form_component_with_enctype(): void {
+		$form = new Form( 'test_form' );
+		$form->enctype( 'multipart/form-data' );
+		$form->fields( new Text( 'name' ) );
+		$component  = new Form_Component( $form );
+		$reflection = new \ReflectionClass( $component );
+
+		$attr_prop = $reflection->getProperty( 'form_attributes' );
+		$attr_prop->setAccessible( true );
+		$this->assertStringContainsString( 'enctype=', $attr_prop->getValue( $component ) );
+		$this->assertStringContainsString( 'multipart/form-data', $attr_prop->getValue( $component ) );
+	}
+
+	/** @testdox Form_Component should set before and after content */
+	public function test_form_component_before_after(): void {
+		$form = new Form( 'test_form' );
+		$form->before( '<h2>Title</h2>' );
+		$form->after( '<p>Footer</p>' );
+		$component  = new Form_Component( $form );
+		$reflection = new \ReflectionClass( $component );
+
+		$before_prop = $reflection->getProperty( 'before_form' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '<h2>Title</h2>', $before_prop->getValue( $component ) );
+
+		$after_prop = $reflection->getProperty( 'after_form' );
+		$after_prop->setAccessible( true );
+		$this->assertEquals( '<p>Footer</p>', $after_prop->getValue( $component ) );
+	}
+
+	/** @testdox Form_Component should default before/after to empty strings */
+	public function test_form_component_no_before_after(): void {
+		$form       = new Form( 'test_form' );
+		$component  = new Form_Component( $form );
+		$reflection = new \ReflectionClass( $component );
+
+		$before_prop = $reflection->getProperty( 'before_form' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '', $before_prop->getValue( $component ) );
+
+		$after_prop = $reflection->getProperty( 'after_form' );
+		$after_prop->setAccessible( true );
+		$this->assertEquals( '', $after_prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######                FIELDSET COMPONENT                     ######
+	####################################################################
+
+	/** @testdox Fieldset_Component should include disabled attribute when set */
+	public function test_fieldset_component_disabled(): void {
+		$fieldset = new Fieldset( 'test_fieldset' );
+		$fieldset->disabled();
+		$fieldset->fields( new Text( 'name' ) );
+		$component  = new Fieldset_Component( $fieldset );
+		$reflection = new \ReflectionClass( $component );
+
+		$attr_prop = $reflection->getProperty( 'fieldset_attributes' );
+		$attr_prop->setAccessible( true );
+		$this->assertStringContainsString( 'disabled', $attr_prop->getValue( $component ) );
+	}
+
+	/** @testdox Fieldset_Component should set legend and before/after */
+	public function test_fieldset_component_legend_and_wrap(): void {
+		$fieldset = new Fieldset( 'test_fieldset' );
+		$fieldset->legend( 'My Fieldset' );
+		$fieldset->before( '<p>Before</p>' );
+		$fieldset->after( '<p>After</p>' );
+		$component  = new Fieldset_Component( $fieldset );
+		$reflection = new \ReflectionClass( $component );
+
+		$legend_prop = $reflection->getProperty( 'legend' );
+		$legend_prop->setAccessible( true );
+		$this->assertEquals( 'My Fieldset', $legend_prop->getValue( $component ) );
+
+		$before_prop = $reflection->getProperty( 'before' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '<p>Before</p>', $before_prop->getValue( $component ) );
+
+		$after_prop = $reflection->getProperty( 'after' );
+		$after_prop->setAccessible( true );
+		$this->assertEquals( '<p>After</p>', $after_prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######            ABSTRACT FIELD COMPONENT                   ######
+	####################################################################
+
+	/** @testdox It should be possible to set before_field on a field component */
+	public function test_abstract_field_before_field(): void {
+		$text      = new Text( 'test' );
+		$component = new Input_Component( $text );
+		$result    = $component->before_field( '<span>Before</span>' );
+		$this->assertSame( $component, $result );
+
+		$reflection = new \ReflectionClass( $component );
+		$prop       = $reflection->getProperty( 'before_field' );
+		$prop->setAccessible( true );
+		$this->assertEquals( '<span>Before</span>', $prop->getValue( $component ) );
+	}
+
+	/** @testdox It should be possible to set after_field on a field component */
+	public function test_abstract_field_after_field(): void {
+		$text      = new Text( 'test' );
+		$component = new Input_Component( $text );
+		$result    = $component->after_field( '<span>After</span>' );
+		$this->assertSame( $component, $result );
+
+		$reflection = new \ReflectionClass( $component );
+		$prop       = $reflection->getProperty( 'after_field' );
+		$prop->setAccessible( true );
+		$this->assertEquals( '<span>After</span>', $prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######               INPUT COMPONENT DETAILS                 ######
+	####################################################################
+
+	/** @testdox Input_Component should set before and after from the field */
+	public function test_input_component_before_after(): void {
+		$text = new Text( 'test' );
+		$text->before( '<span>Before</span>' );
+		$text->after( '<span>After</span>' );
+		$component  = new Input_Component( $text );
+		$reflection = new \ReflectionClass( $component );
+
+		$before_prop = $reflection->getProperty( 'before_field' );
+		$before_prop->setAccessible( true );
+		$this->assertEquals( '<span>Before</span>', $before_prop->getValue( $component ) );
+
+		$after_prop = $reflection->getProperty( 'after_field' );
+		$after_prop->setAccessible( true );
+		$this->assertEquals( '<span>After</span>', $after_prop->getValue( $component ) );
+	}
+
+	/** @testdox Input_Component should accept additional attributes */
+	public function test_input_component_with_extra_attributes(): void {
+		$text      = new Text( 'test' );
+		$component = new Input_Component( $text, array( 'data-custom' => 'value' ) );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	/** @testdox Input_Component should include wrapper id when not explicitly set */
+	public function test_input_component_auto_wrapper_id(): void {
+		$text = new Text( 'my_field' );
+
+		// Remove the auto-set wrapper id so set_wrapper_attributes generates one
+		$text->remove_wrapper_attribute( 'id' );
+
+		$component  = new Input_Component( $text );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'wrapper_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'field_my_field_wrapper', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Input_Component should keep existing wrapper id */
+	public function test_input_component_existing_wrapper_id(): void {
+		$text = new Text( 'my_field' );
+		$text->wrapper_attribute( 'id', 'custom_wrapper' );
+		$component  = new Input_Component( $text );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'wrapper_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'custom_wrapper', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Input_Component should set show_wrapper from field */
+	public function test_input_component_show_wrapper(): void {
+		$text = new Text( 'test' );
+		$text->show_wrapper( false );
+		$component  = new Input_Component( $text );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'show_wrapper' );
+		$prop->setAccessible( true );
+		$this->assertFalse( $prop->getValue( $component ) );
+	}
+
+	/** @testdox Input_Component should include datalist key in base attributes for fields with Datalist trait */
+	public function test_input_component_datalist_base_attribute(): void {
+		$text = new Text( 'test' );
+		$text->datalist_item( 'opt1', 'Label 1' );
+		$component  = new Input_Component( $text );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'field_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'list=', $prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######              BUTTON COMPONENT DETAILS                 ######
+	####################################################################
+
+	/** @testdox Button_Component should store type and text */
+	public function test_button_component_properties(): void {
+		$button = new Button( 'test_btn' );
+		$button->type( 'submit' );
+		$button->text( 'Submit Form' );
+		$button->before( '<div>' );
+		$button->after( '</div>' );
+		$component  = new Button_Component( $button );
+		$reflection = new \ReflectionClass( $component );
+
+		$type_prop = $reflection->getProperty( 'type' );
+		$type_prop->setAccessible( true );
+		$this->assertEquals( 'submit', $type_prop->getValue( $component ) );
+
+		$text_prop = $reflection->getProperty( 'text' );
+		$text_prop->setAccessible( true );
+		$this->assertEquals( 'submit form', $text_prop->getValue( $component ) );
+	}
+
+	/** @testdox Button_Component should accept additional attributes */
+	public function test_button_component_with_extra_attributes(): void {
+		$button    = new Button( 'test' );
+		$component = new Button_Component( $button, array( 'data-action' => 'submit' ) );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	####################################################################
+	######              SELECT COMPONENT DETAILS                 ######
+	####################################################################
+
+	/** @testdox Select_Component should set field attributes with base class */
+	public function test_select_component_attributes(): void {
+		$select = new Select( 'my_select' );
+		$select->before( '<label>Pick one</label>' );
+		$select->after( '<small>Help</small>' );
+		$component  = new Select_Component( $select );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'field_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'class=', $prop->getValue( $component ) );
+		$this->assertStringContainsString( 'select', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Select_Component should accept additional attributes */
+	public function test_select_component_with_extra_attributes(): void {
+		$select    = new Select( 'test' );
+		$component = new Select_Component( $select, array( 'data-search' => 'true' ) );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	####################################################################
+	######             TEXTAREA COMPONENT DETAILS                ######
+	####################################################################
+
+	/** @testdox Textarea_Component should set field attributes with base class */
+	public function test_textarea_component_attributes(): void {
+		$textarea = new Textarea( 'my_textarea' );
+		$textarea->before( '<label>Content</label>' );
+		$textarea->after( '<small>Max 500 chars</small>' );
+		$component  = new Textarea_Component( $textarea );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'field_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'textarea', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Textarea_Component should accept additional attributes */
+	public function test_textarea_component_with_extra_attributes(): void {
+		$textarea  = new Textarea( 'test' );
+		$component = new Textarea_Component( $textarea, array( 'rows' => '5' ) );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	####################################################################
+	######          CHECKBOX GROUP COMPONENT DETAILS             ######
+	####################################################################
+
+	/** @testdox Checkbox_Group_Component should set field attributes with base class */
+	public function test_checkbox_group_component_attributes(): void {
+		$group = new Checkbox_Group( 'my_checks' );
+		$group->before( '<p>Select all</p>' );
+		$group->after( '<p>Done</p>' );
+		$component  = new Checkbox_Group_Component( $group );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'field_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'checkbox-group', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Checkbox_Group_Component should accept additional attributes */
+	public function test_checkbox_group_component_with_extra_attributes(): void {
+		$group     = new Checkbox_Group( 'test' );
+		$component = new Checkbox_Group_Component( $group, array( 'data-max' => '3' ) );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	####################################################################
+	######           RADIO GROUP COMPONENT DETAILS               ######
+	####################################################################
+
+	/** @testdox Radio_Group_Component should set field attributes with base class */
+	public function test_radio_group_component_attributes(): void {
+		$group = new Radio_Group( 'my_radios' );
+		$group->before( '<p>Choose one</p>' );
+		$group->after( '<p>End</p>' );
+		$component  = new Radio_Group_Component( $group );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'field_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'radio-group', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Radio_Group_Component should accept additional attributes */
+	public function test_radio_group_component_with_extra_attributes(): void {
+		$group     = new Radio_Group( 'test' );
+		$component = new Radio_Group_Component( $group, array( 'data-required' => 'true' ) );
+		$this->assertInstanceOf( Component::class, $component );
+	}
+
+	####################################################################
+	######            RAW HTML COMPONENT DETAILS                 ######
+	####################################################################
+
+	/** @testdox Raw_HTML_Component should store the html from the element */
+	public function test_raw_html_component_stores_html(): void {
+		$html      = new Raw_HTML( 'divider' );
+		$html->html( '<hr class="divider">' );
+		$component  = new Raw_HTML_Component( $html );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'html' );
+		$prop->setAccessible( true );
+		$this->assertEquals( '<hr class="divider">', $prop->getValue( $component ) );
+	}
+}

--- a/tests/Unit/Element/Input/Test_Abstract_Input_Methods.php
+++ b/tests/Unit/Element/Input/Test_Abstract_Input_Methods.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for Abstract_Input methods not covered by field-specific tests.
+ * Tests tabindex, set_existing, and get_type/get_input_type.
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Element\Input;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Util\Sanitize;
+use PinkCrab\Form_Components\Element\Field\Input\Text;
+use PinkCrab\Form_Components\Element\Field\Input\Number;
+
+/**
+ * @group unit
+ * @group element
+ * @group input
+ * @group abstract_input
+ */
+class Test_Abstract_Input_Methods extends WP_UnitTestCase {
+
+	####################################################################
+	######                     TABINDEX                          ######
+	####################################################################
+
+	/** @testdox It should be possible to set a tabindex on an input */
+	public function test_tabindex_set(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_tabindex() );
+		$text->tabindex( '5' );
+		$this->assertTrue( $text->has_tabindex() );
+		$this->assertEquals( '5', $text->get_tabindex() );
+	}
+
+	/** @testdox A field without tabindex should return null */
+	public function test_tabindex_not_set(): void {
+		$text = new Text( 'test' );
+		$this->assertNull( $text->get_tabindex() );
+	}
+
+	/** @testdox It should be possible to clear the tabindex */
+	public function test_tabindex_clear(): void {
+		$text = new Text( 'test' );
+		$text->tabindex( '3' );
+		$this->assertTrue( $text->has_tabindex() );
+		$text->clear_tabindex();
+		$this->assertFalse( $text->has_tabindex() );
+		$this->assertNull( $text->get_tabindex() );
+	}
+
+	/** @testdox Clearing tabindex when not set should not throw */
+	public function test_tabindex_clear_when_not_set(): void {
+		$text = new Text( 'test' );
+		$text->clear_tabindex();
+		$this->assertFalse( $text->has_tabindex() );
+	}
+
+	####################################################################
+	######                    SET_EXISTING                        ######
+	####################################################################
+
+	/** @testdox It should be possible to set an existing value on a field with a sanitizer */
+	public function test_set_existing_with_sanitizer(): void {
+		$text = new Text( 'test' );
+		$text->set_existing( 'hello world' );
+		$this->assertEquals( 'hello world', $text->get_value() );
+	}
+
+	/** @testdox Set existing should sanitize the value using the field's sanitizer */
+	public function test_set_existing_sanitizes(): void {
+		$text = new Text( 'test' );
+		$text->set_existing( '<script>alert("xss")</script>' );
+		// The sanitizer should strip the script tag
+		$this->assertStringNotContainsString( '<script>', $text->get_value() );
+	}
+
+	/** @testdox Set existing should work on a field without a sanitizer */
+	public function test_set_existing_without_sanitizer(): void {
+		$number = new Number( 'test' );
+		$number->set_existing( '42' );
+		// Number sanitizer converts to int, then value() stores it
+		$this->assertNotNull( $number->get_value() );
+	}
+
+	####################################################################
+	######                   GET_TYPE                             ######
+	####################################################################
+
+	/** @testdox get_type should return the input type suffixed with _input */
+	public function test_get_type_format(): void {
+		$text   = new Text( 'test' );
+		$number = new Number( 'test' );
+		$this->assertEquals( 'text_input', $text->get_type() );
+		$this->assertEquals( 'number_input', $number->get_type() );
+	}
+
+	/** @testdox get_input_type should return the raw input type */
+	public function test_get_input_type(): void {
+		$text   = new Text( 'test' );
+		$number = new Number( 'test' );
+		$this->assertEquals( 'text', $text->get_input_type() );
+		$this->assertEquals( 'number', $number->get_input_type() );
+	}
+
+	####################################################################
+	######              SANITIZE WITHOUT SANITIZER                ######
+	####################################################################
+
+	/** @testdox Calling sanitize when no sanitizer is set should return the value as-is */
+	public function test_sanitize_without_sanitizer(): void {
+		$text = new Text( 'test' );
+		$text->sanitizer( null );
+		$this->assertEquals( 'raw_value', $text->sanitize( 'raw_value' ) );
+	}
+
+	####################################################################
+	######              FORM_STYLE GUARD                          ######
+	####################################################################
+
+	/** @testdox Getting style when not set should throw RuntimeException */
+	public function test_get_style_throws_when_null(): void {
+		$text = new Text( 'test' );
+		// Clear the style via reflection
+		$reflection = new \ReflectionClass( $text );
+		$prop       = $reflection->getProperty( 'form_style' );
+		$prop->setAccessible( true );
+		$prop->setValue( $text, null );
+
+		$this->expectException( \RuntimeException::class );
+		$text->get_style();
+	}
+
+	/** @testdox has_explicit_style should return false by default and true after calling style() */
+	public function test_has_explicit_style(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_explicit_style() );
+		$text->style( new \PinkCrab\Form_Components\Style\Default_Style() );
+		$this->assertTrue( $text->has_explicit_style() );
+	}
+}

--- a/tests/Unit/Element/Input/Test_Checkbox.php
+++ b/tests/Unit/Element/Input/Test_Checkbox.php
@@ -105,4 +105,46 @@ class Test_Checkbox extends WP_UnitTestCase {
 		$checkbox = new Checkbox( 'test' );
 		$this->assertTrue( method_exists( $checkbox, $method ) );
 	}
+
+	####################################################################
+	######                    CHECKED TRAIT                       ######
+	####################################################################
+
+	/** @testdox It should be possible to set a checkbox as checked */
+	public function test_checked_set(): void {
+		$checkbox = new Checkbox( 'test' );
+		$this->assertFalse( $checkbox->is_checked() );
+		$checkbox->checked();
+		$this->assertTrue( $checkbox->is_checked() );
+	}
+
+	/** @testdox It should be possible to uncheck a checkbox */
+	public function test_checked_unset(): void {
+		$checkbox = new Checkbox( 'test' );
+		$checkbox->checked( true );
+		$this->assertTrue( $checkbox->is_checked() );
+		$checkbox->checked( false );
+		$this->assertFalse( $checkbox->is_checked() );
+	}
+
+	####################################################################
+	######                   DISABLED TRAIT                       ######
+	####################################################################
+
+	/** @testdox It should be possible to set a checkbox as disabled */
+	public function test_disabled_set(): void {
+		$checkbox = new Checkbox( 'test' );
+		$this->assertFalse( $checkbox->is_disabled() );
+		$checkbox->disabled();
+		$this->assertTrue( $checkbox->is_disabled() );
+	}
+
+	/** @testdox It should be possible to unset disabled on a checkbox */
+	public function test_disabled_unset(): void {
+		$checkbox = new Checkbox( 'test' );
+		$checkbox->disabled( true );
+		$this->assertTrue( $checkbox->is_disabled() );
+		$checkbox->disabled( false );
+		$this->assertFalse( $checkbox->is_disabled() );
+	}
 }

--- a/tests/Unit/Element/Input/Test_Number.php
+++ b/tests/Unit/Element/Input/Test_Number.php
@@ -94,4 +94,142 @@ class Test_Number extends WP_UnitTestCase {
 		$this->assertTrue( usesTrait( Read_Only::class )( $number ) );
 	}
 
+	####################################################################
+	######                     RANGE TRAIT                        ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get a min value */
+	public function test_range_min(): void {
+		$number = new Number( 'test' );
+		$this->assertNull( $number->get_min() );
+		$number->min( 5 );
+		$this->assertEquals( '5', $number->get_min() );
+	}
+
+	/** @testdox Passing null to min should remove it */
+	public function test_range_min_null(): void {
+		$number = new Number( 'test' );
+		$number->min( 5 );
+		$this->assertEquals( '5', $number->get_min() );
+		$number->min( null );
+		$this->assertNull( $number->get_min() );
+	}
+
+	/** @testdox It should be possible to set and get a max value */
+	public function test_range_max(): void {
+		$number = new Number( 'test' );
+		$this->assertNull( $number->get_max() );
+		$number->max( 100 );
+		$this->assertEquals( '100', $number->get_max() );
+	}
+
+	/** @testdox Passing null to max should remove it */
+	public function test_range_max_null(): void {
+		$number = new Number( 'test' );
+		$number->max( 100 );
+		$this->assertEquals( '100', $number->get_max() );
+		$number->max( null );
+		$this->assertNull( $number->get_max() );
+	}
+
+	/** @testdox It should be possible to set both min and max using range */
+	public function test_range_set(): void {
+		$number = new Number( 'test' );
+		$number->range( 1, 50 );
+		$this->assertEquals( '1', $number->get_min() );
+		$this->assertEquals( '50', $number->get_max() );
+	}
+
+	####################################################################
+	######                      STEP TRAIT                        ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get the step attribute */
+	public function test_step_set_and_get(): void {
+		$number = new Number( 'test' );
+		$this->assertFalse( $number->has_step() );
+		$this->assertNull( $number->get_step() );
+		$number->step( 2 );
+		$this->assertTrue( $number->has_step() );
+		$this->assertEquals( '2', $number->get_step() );
+	}
+
+	/** @testdox It should be possible to set a float step value */
+	public function test_step_float(): void {
+		$number = new Number( 'test' );
+		$number->step( 0.5 );
+		$this->assertTrue( $number->has_step() );
+		$this->assertEquals( '0.5', $number->get_step() );
+	}
+
+	/** @testdox It should be possible to clear the step attribute */
+	public function test_step_clear(): void {
+		$number = new Number( 'test' );
+		$number->step( 5 );
+		$this->assertTrue( $number->has_step() );
+		$number->clear_step();
+		$this->assertFalse( $number->has_step() );
+		$this->assertNull( $number->get_step() );
+	}
+
+	/** @testdox Clearing step when not set should not throw */
+	public function test_step_clear_when_not_set(): void {
+		$number = new Number( 'test' );
+		$number->clear_step();
+		$this->assertFalse( $number->has_step() );
+	}
+
+	####################################################################
+	######                   PLACEHOLDER TRAIT                    ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get a placeholder on Number */
+	public function test_placeholder_set_and_get(): void {
+		$number = new Number( 'test' );
+		$this->assertFalse( $number->has_placeholder() );
+		$this->assertNull( $number->get_placeholder() );
+		$number->placeholder( 'Enter a number' );
+		$this->assertTrue( $number->has_placeholder() );
+		$this->assertEquals( 'Enter a number', $number->get_placeholder() );
+	}
+
+	####################################################################
+	######                    READ_ONLY TRAIT                     ######
+	####################################################################
+
+	/** @testdox It should be possible to set and unset readonly on Number */
+	public function test_readonly_set_and_unset(): void {
+		$number = new Number( 'test' );
+		$this->assertFalse( $number->is_readonly() );
+		$number->readonly();
+		$this->assertTrue( $number->is_readonly() );
+		$number->readonly( false );
+		$this->assertFalse( $number->is_readonly() );
+	}
+
+	####################################################################
+	######                    REQUIRED TRAIT                      ######
+	####################################################################
+
+	/** @testdox It should be possible to set and unset required on Number */
+	public function test_required_set_and_unset(): void {
+		$number = new Number( 'test' );
+		$this->assertFalse( $number->is_required() );
+		$number->required();
+		$this->assertTrue( $number->is_required() );
+		$number->required( false );
+		$this->assertFalse( $number->is_required() );
+	}
+
+	####################################################################
+	######                  AUTOCOMPLETE TRAIT                    ######
+	####################################################################
+
+	/** @testdox It should be possible to set autocomplete on Number */
+	public function test_autocomplete_set_and_get(): void {
+		$number = new Number( 'test' );
+		$number->autocomplete( 'off' );
+		$this->assertTrue( $number->has_autocomplete() );
+		$this->assertEquals( 'off', $number->get_autocomplete() );
+	}
 }

--- a/tests/Unit/Element/Input/Test_Radio.php
+++ b/tests/Unit/Element/Input/Test_Radio.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the Radio Input
+ * Extends Abstract_Input
+ * Extends Field
+ * Implements Element
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Element\Input;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Element\Field\Input\Radio;
+use PinkCrab\Form_Components\Tests\Fixtures\Mock_Objects\Stringable_Stub;
+use function PinkCrab\FunctionConstructors\Objects\usesTrait;
+use PinkCrab\Form_Components\Element\Field\Attribute\{Checked, Disabled};
+
+/**
+ * @group unit
+ * @group element
+ * @group input
+ */
+class Test_Radio extends WP_UnitTestCase {
+
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+
+	/** @inheritDoc */
+	public function get_class_under_test(): string {
+		return Radio::class;
+	}
+
+	/** @testdox A Radio input should return an input type of "radio" */
+	public function test_type(): void {
+		$radio = new Radio( 'test' );
+		$this->assertEquals( 'radio', $radio->get_input_type() );
+	}
+
+	/** @testdox A Radio input should return a type of radio_input */
+	public function test_element_type(): void {
+		$radio = new Radio( 'test' );
+		$this->assertEquals( 'radio_input', $radio->get_type() );
+	}
+
+	/** @testdox By default the radio field should have no sanitizer. */
+	public function test_default_sanitizer(): void {
+		$radio = new Radio( 'test' );
+		$this->assertNull( $radio->get_sanitizer() );
+	}
+
+	####################################################################
+	######                     FIELD SPECIFIC                     ######
+	####################################################################
+
+	/**
+	 * Data provider for ensuring the value is set as a string.
+	 *
+	 * @return array<string, array{0:string,1:mixed}>
+	 */
+	public function data_provider(): array {
+		return array(
+			'String'     => array( 'a_string', 'a_string' ),
+			'Integer'    => array( '1', 1 ),
+			'Float'      => array( '1.1', 1.1 ),
+			'Stringable' => array( 'stringable', new Stringable_Stub( 'stringable' ) ),
+		);
+	}
+
+	/**
+	 * @testdox All values passed to the Radio field should be cast to string.
+	 * @dataProvider data_provider
+	 */
+	public function test_value_cast_to_string( string $expected, $value ): void {
+		$radio = new Radio( 'test' );
+		$radio->value( $value );
+		$this->assertEquals( $expected, $radio->get_value() );
+	}
+
+	####################################################################
+	######                    CHECKED TRAIT                       ######
+	####################################################################
+
+	/** @testdox It should be possible to set a radio as checked */
+	public function test_checked_set(): void {
+		$radio = new Radio( 'test' );
+		$this->assertFalse( $radio->is_checked() );
+		$radio->checked();
+		$this->assertTrue( $radio->is_checked() );
+	}
+
+	/** @testdox It should be possible to uncheck a radio */
+	public function test_checked_unset(): void {
+		$radio = new Radio( 'test' );
+		$radio->checked( true );
+		$this->assertTrue( $radio->is_checked() );
+		$radio->checked( false );
+		$this->assertFalse( $radio->is_checked() );
+	}
+
+	####################################################################
+	######                   DISABLED TRAIT                       ######
+	####################################################################
+
+	/** @testdox It should be possible to set a radio as disabled */
+	public function test_disabled_set(): void {
+		$radio = new Radio( 'test' );
+		$this->assertFalse( $radio->is_disabled() );
+		$radio->disabled();
+		$this->assertTrue( $radio->is_disabled() );
+	}
+
+	/** @testdox It should be possible to unset disabled on a radio */
+	public function test_disabled_unset(): void {
+		$radio = new Radio( 'test' );
+		$radio->disabled( true );
+		$this->assertTrue( $radio->is_disabled() );
+		$radio->disabled( false );
+		$this->assertFalse( $radio->is_disabled() );
+	}
+
+	####################################################################
+	######                    SHARED ATTRIBUTES                   ######
+	####################################################################
+
+	/**
+	 * The methods that should be defined by the traits to represent shared attributes.
+	 *
+	 * @return array<string, array<string>>
+	 */
+	public function attribute_methods(): array {
+		return array(
+			'checked'  => array( 'checked' ),
+			'disabled' => array( 'disabled' ),
+		);
+	}
+
+	/**
+	 * @testdox This input field has all attributes as defined by the shared traits
+	 * @dataProvider attribute_methods
+	 */
+	public function test_has_attributes( string $method ): void {
+		$radio = new Radio( 'test' );
+		$this->assertTrue( method_exists( $radio, $method ) );
+	}
+}

--- a/tests/Unit/Element/Input/Test_Text.php
+++ b/tests/Unit/Element/Input/Test_Text.php
@@ -33,7 +33,7 @@ class Test_Text extends WP_UnitTestCase {
 	public function get_class_under_test(): string {
 		return Text::class;
 	}
-    
+
     /** @testdox A Text input should return an input type of "TEXT" */
 	public function test_type(): void {
 		$text = new Text( 'test' );
@@ -65,7 +65,7 @@ class Test_Text extends WP_UnitTestCase {
 
 	/**
      * The methods that should be defined by the traits to represent shared attributes.
-     * 
+     *
      * @return array<string, array<string>>
      */
     public function attribute_methods(): array {
@@ -82,7 +82,7 @@ class Test_Text extends WP_UnitTestCase {
         );
     }
 
-    /** 
+    /**
      * @testdox This input field has all attributes as defined by the shared traits
      * @dataProvider attribute_methods
      */
@@ -90,4 +90,389 @@ class Test_Text extends WP_UnitTestCase {
         $text = new Text( 'test' );
         $this->assertTrue( method_exists( $text, $method ) );
     }
+
+	####################################################################
+	######                   AUTOCOMPLETE TRAIT                   ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get the autocomplete attribute */
+	public function test_autocomplete_set_and_get(): void {
+		$text = new Text( 'test' );
+		$text->autocomplete( 'email' );
+		$this->assertTrue( $text->has_autocomplete() );
+		$this->assertEquals( 'email', $text->get_autocomplete() );
+	}
+
+	/** @testdox Autocomplete should default to 'on' when called without argument */
+	public function test_autocomplete_default(): void {
+		$text = new Text( 'test' );
+		$text->autocomplete();
+		$this->assertEquals( 'on', $text->get_autocomplete() );
+	}
+
+	/** @testdox Passing null to autocomplete should remove the attribute */
+	public function test_autocomplete_remove_with_null(): void {
+		$text = new Text( 'test' );
+		$text->autocomplete( 'on' );
+		$this->assertTrue( $text->has_autocomplete() );
+		$text->autocomplete( null );
+		$this->assertFalse( $text->has_autocomplete() );
+		$this->assertNull( $text->get_autocomplete() );
+	}
+
+	####################################################################
+	######                     PATTERN TRAIT                      ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get a validation pattern */
+	public function test_pattern_set_and_get(): void {
+		$text = new Text( 'test' );
+		$text->pattern( '[A-Za-z]+' );
+		$this->assertTrue( $text->has_pattern() );
+		$this->assertEquals( '[A-Za-z]+', $text->get_pattern() );
+	}
+
+	/** @testdox Passing null to pattern should remove the attribute */
+	public function test_pattern_remove_with_null(): void {
+		$text = new Text( 'test' );
+		$text->pattern( '[0-9]+' );
+		$this->assertTrue( $text->has_pattern() );
+		$text->pattern( null );
+		$this->assertFalse( $text->has_pattern() );
+		$this->assertNull( $text->get_pattern() );
+	}
+
+	####################################################################
+	######                   PLACEHOLDER TRAIT                    ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get a placeholder */
+	public function test_placeholder_set_and_get(): void {
+		$text = new Text( 'test' );
+		$text->placeholder( 'Enter your name' );
+		$this->assertTrue( $text->has_placeholder() );
+		$this->assertEquals( 'Enter your name', $text->get_placeholder() );
+	}
+
+	/** @testdox Passing null to placeholder should remove the attribute */
+	public function test_placeholder_remove_with_null(): void {
+		$text = new Text( 'test' );
+		$text->placeholder( 'Some text' );
+		$this->assertTrue( $text->has_placeholder() );
+		$text->placeholder( null );
+		$this->assertFalse( $text->has_placeholder() );
+		$this->assertNull( $text->get_placeholder() );
+	}
+
+	####################################################################
+	######                    READ_ONLY TRAIT                     ######
+	####################################################################
+
+	/** @testdox It should be possible to set a field as readonly */
+	public function test_readonly_set(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->is_readonly() );
+		$text->readonly();
+		$this->assertTrue( $text->is_readonly() );
+	}
+
+	/** @testdox It should be possible to unset readonly */
+	public function test_readonly_unset(): void {
+		$text = new Text( 'test' );
+		$text->readonly( true );
+		$this->assertTrue( $text->is_readonly() );
+		$text->readonly( false );
+		$this->assertFalse( $text->is_readonly() );
+	}
+
+	####################################################################
+	######                    REQUIRED TRAIT                      ######
+	####################################################################
+
+	/** @testdox It should be possible to set a field as required */
+	public function test_required_set(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->is_required() );
+		$text->required();
+		$this->assertTrue( $text->is_required() );
+	}
+
+	/** @testdox It should be possible to unset required */
+	public function test_required_unset(): void {
+		$text = new Text( 'test' );
+		$text->required( true );
+		$this->assertTrue( $text->is_required() );
+		$text->required( false );
+		$this->assertFalse( $text->is_required() );
+	}
+
+	####################################################################
+	######                     LENGTH TRAIT                       ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get the minlength attribute */
+	public function test_minlength_set_and_get(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_minlength() );
+		$this->assertNull( $text->get_minlength() );
+		$text->minlength( 5 );
+		$this->assertTrue( $text->has_minlength() );
+		$this->assertEquals( '5', $text->get_minlength() );
+	}
+
+	/** @testdox Passing null to minlength should remove it */
+	public function test_minlength_remove_with_null(): void {
+		$text = new Text( 'test' );
+		$text->minlength( 5 );
+		$this->assertTrue( $text->has_minlength() );
+		$text->minlength( null );
+		$this->assertFalse( $text->has_minlength() );
+	}
+
+	/** @testdox It should be possible to set and get the maxlength attribute */
+	public function test_maxlength_set_and_get(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_maxlength() );
+		$this->assertNull( $text->get_maxlength() );
+		$text->maxlength( 100 );
+		$this->assertTrue( $text->has_maxlength() );
+		$this->assertEquals( '100', $text->get_maxlength() );
+	}
+
+	/** @testdox Passing null to maxlength should remove it */
+	public function test_maxlength_remove_with_null(): void {
+		$text = new Text( 'test' );
+		$text->maxlength( 100 );
+		$this->assertTrue( $text->has_maxlength() );
+		$text->maxlength( null );
+		$this->assertFalse( $text->has_maxlength() );
+	}
+
+	####################################################################
+	######                   INPUT_MODE TRAIT                     ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get the inputmode attribute */
+	public function test_inputmode_set_and_get(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_inputmode() );
+		$this->assertNull( $text->get_inputmode() );
+		$text->inputmode( 'numeric' );
+		$this->assertTrue( $text->has_inputmode() );
+		$this->assertEquals( 'numeric', $text->get_inputmode() );
+	}
+
+	/** @testdox It should be possible to clear the inputmode attribute */
+	public function test_inputmode_clear(): void {
+		$text = new Text( 'test' );
+		$text->inputmode( 'numeric' );
+		$this->assertTrue( $text->has_inputmode() );
+		$text->clear_inputmode();
+		$this->assertFalse( $text->has_inputmode() );
+		$this->assertNull( $text->get_inputmode() );
+	}
+
+	####################################################################
+	######                   SPELLCHECK TRAIT                     ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get the spellcheck attribute */
+	public function test_spellcheck_set_and_get(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_spellcheck() );
+		$this->assertNull( $text->get_spellcheck() );
+		$text->spellcheck( 'true' );
+		$this->assertTrue( $text->has_spellcheck() );
+		$this->assertEquals( 'true', $text->get_spellcheck() );
+	}
+
+	/** @testdox It should be possible to clear the spellcheck attribute */
+	public function test_spellcheck_clear(): void {
+		$text = new Text( 'test' );
+		$text->spellcheck( 'true' );
+		$this->assertTrue( $text->has_spellcheck() );
+		$text->clear_spellcheck();
+		$this->assertFalse( $text->has_spellcheck() );
+		$this->assertNull( $text->get_spellcheck() );
+	}
+
+	####################################################################
+	######                      SIZE TRAIT                        ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get the size attribute */
+	public function test_size_set_and_get(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_size() );
+		$this->assertNull( $text->get_size() );
+		$text->size( 20 );
+		$this->assertTrue( $text->has_size() );
+		$this->assertEquals( '20', $text->get_size() );
+	}
+
+	/** @testdox Passing null to size should remove it */
+	public function test_size_remove_with_null(): void {
+		$text = new Text( 'test' );
+		$text->size( 20 );
+		$this->assertTrue( $text->has_size() );
+		$text->size( null );
+		$this->assertFalse( $text->has_size() );
+		$this->assertNull( $text->get_size() );
+	}
+
+	/** @testdox Passing a non-numeric value to size should remove it */
+	public function test_size_non_numeric(): void {
+		$text = new Text( 'test' );
+		$text->size( 20 );
+		$this->assertTrue( $text->has_size() );
+		$text->size( 'abc' );
+		$this->assertFalse( $text->has_size() );
+	}
+
+	####################################################################
+	######                    DISABLED TRAIT                      ######
+	####################################################################
+
+	/** @testdox It should be possible to set a field as disabled */
+	public function test_disabled_set(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->is_disabled() );
+		$text->disabled();
+		$this->assertTrue( $text->is_disabled() );
+	}
+
+	/** @testdox It should be possible to unset disabled */
+	public function test_disabled_unset(): void {
+		$text = new Text( 'test' );
+		$text->disabled( true );
+		$this->assertTrue( $text->is_disabled() );
+		$text->disabled( false );
+		$this->assertFalse( $text->is_disabled() );
+	}
+
+	####################################################################
+	######                    DATALIST TRAIT                      ######
+	####################################################################
+
+	/** @testdox It should be possible to add datalist items */
+	public function test_datalist_add_items(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_datalist_items() );
+		$text->datalist_item( 'option1', 'Label 1' );
+		$this->assertTrue( $text->has_datalist_items() );
+		$items = $text->get_datalist_items();
+		$this->assertArrayHasKey( 'option1', $items );
+		$this->assertEquals( 'Label 1', $items['option1'] );
+	}
+
+	/** @testdox It should be possible to add multiple datalist items at once */
+	public function test_datalist_items_array(): void {
+		$text = new Text( 'test' );
+		$text->datalist_items( array( 'opt1' => 'Label 1', 'opt2' => 'Label 2' ) );
+		$this->assertTrue( $text->has_datalist_items() );
+		$items = $text->get_datalist_items();
+		$this->assertCount( 2, $items );
+	}
+
+	/** @testdox It should be possible to add datalist items as a flat list */
+	public function test_datalist_items_flat_list(): void {
+		$text = new Text( 'test' );
+		$text->datalist_items( array( 'Option A', 'Option B', 'Option C' ) );
+		$this->assertTrue( $text->has_datalist_items() );
+		$items = $text->get_datalist_items();
+		$this->assertCount( 3, $items );
+	}
+
+	/** @testdox It should be possible to set a custom datalist key */
+	public function test_datalist_key(): void {
+		$text = new Text( 'test' );
+		$text->datalist_key( 'my_custom_list' );
+		$this->assertEquals( 'my_custom_list', $text->get_datalist_key() );
+	}
+
+	/** @testdox The datalist key should auto-generate based on field name */
+	public function test_datalist_key_auto_generated(): void {
+		$text = new Text( 'test' );
+		$key  = $text->get_datalist_key();
+		$this->assertStringContainsString( 'test', $key );
+	}
+
+	####################################################################
+	######                  NOTIFICATION TRAIT                    ######
+	####################################################################
+
+	/** @testdox It should be possible to set a notification on a field */
+	public function test_notification_set(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_notification() );
+		$text->notification( 'This is required' );
+		$this->assertTrue( $text->has_notification() );
+		$this->assertEquals( 'This is required', $text->get_notification() );
+		$this->assertEquals( 'info', $text->get_notification_type() );
+	}
+
+	/** @testdox It should be possible to set an info notification */
+	public function test_info_notification(): void {
+		$text = new Text( 'test' );
+		$text->info_notification( 'Info message' );
+		$this->assertTrue( $text->has_notification() );
+		$this->assertEquals( 'Info message', $text->get_notification() );
+		$this->assertEquals( 'info', $text->get_notification_type() );
+	}
+
+	/** @testdox It should be possible to set a success notification */
+	public function test_success_notification(): void {
+		$text = new Text( 'test' );
+		$text->success_notification( 'Success!' );
+		$this->assertTrue( $text->has_notification() );
+		$this->assertEquals( 'Success!', $text->get_notification() );
+		$this->assertEquals( 'success', $text->get_notification_type() );
+	}
+
+	/** @testdox It should be possible to set a warning notification */
+	public function test_warning_notification(): void {
+		$text = new Text( 'test' );
+		$text->warning_notification( 'Warning!' );
+		$this->assertTrue( $text->has_notification() );
+		$this->assertEquals( 'Warning!', $text->get_notification() );
+		$this->assertEquals( 'warning', $text->get_notification_type() );
+	}
+
+	/** @testdox It should be possible to set an error notification */
+	public function test_error_notification(): void {
+		$text = new Text( 'test' );
+		$text->error_notification( 'Error!' );
+		$this->assertTrue( $text->has_notification() );
+		$this->assertEquals( 'Error!', $text->get_notification() );
+		$this->assertEquals( 'error', $text->get_notification_type() );
+	}
+
+	/** @testdox Changing a notification type should remove the previous notification classes */
+	public function test_notification_type_change_removes_old(): void {
+		$text = new Text( 'test' );
+		$text->info_notification( 'Info' );
+		$text->error_notification( 'Error' );
+		$this->assertEquals( 'error', $text->get_notification_type() );
+		$this->assertEquals( 'Error', $text->get_notification() );
+	}
+
+	/** @testdox A field with no notification should return empty string */
+	public function test_no_notification_returns_empty(): void {
+		$text = new Text( 'test' );
+		$this->assertEquals( '', $text->get_notification() );
+	}
+
+	####################################################################
+	######                     LABEL TRAIT                        ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get a label */
+	public function test_label_set_and_get(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_label() );
+		$this->assertNull( $text->get_label() );
+		$text->label( 'My Label' );
+		$this->assertTrue( $text->has_label() );
+		$this->assertEquals( 'My Label', $text->get_label() );
+	}
 }

--- a/tests/Unit/Element/Test_Button_Element.php
+++ b/tests/Unit/Element/Test_Button_Element.php
@@ -140,4 +140,66 @@ class Test_Button_Element extends WP_UnitTestCase {
 		$button->after( '<span>After</span>' );
 		$this->assertEquals( '<span>After</span>', $button->get_after() );
 	}
+
+	/** @testdox Getting a non-class attribute should return null if not set */
+	public function test_get_attribute_non_class_returns_null(): void {
+		$button = new Button( 'test' );
+		$this->assertNull( $button->get_attribute( 'data-something' ) );
+	}
+
+	/** @testdox Getting a non-class attribute that exists should return its value */
+	public function test_get_attribute_non_class_returns_value(): void {
+		$button = new Button( 'test' );
+		$button->attribute( 'data-action', 'submit' );
+		$this->assertEquals( 'submit', $button->get_attribute( 'data-action' ) );
+	}
+
+	/** @testdox It should be possible to construct a Button with a custom style */
+	public function test_custom_style(): void {
+		$style  = new Default_Style();
+		$button = new Button( 'test', $style );
+		$this->assertSame( $style, $button->get_style() );
+	}
+
+	/** @testdox Getting wrapper class attribute should include element wrapper style */
+	public function test_get_wrapper_attribute_class(): void {
+		$button = new Button( 'test' );
+		$class  = $button->get_wrapper_attribute( 'class' );
+		$this->assertStringContainsString( 'pc-form__element', $class );
+		$this->assertStringContainsString( 'button', $class );
+	}
+
+	/** @testdox Getting wrapper class with custom class should merge */
+	public function test_get_wrapper_attribute_class_with_custom(): void {
+		$button = new Button( 'test' );
+		$button->add_wrapper_class( 'my-custom' );
+		$class = $button->get_wrapper_attribute( 'class' );
+		$this->assertStringContainsString( 'my-custom', $class );
+		$this->assertStringContainsString( 'pc-form__element', $class );
+	}
+
+	/** @testdox Getting all wrapper attributes should include style classes */
+	public function test_get_wrapper_attributes(): void {
+		$button = new Button( 'test' );
+		$attrs  = $button->get_wrapper_attributes();
+		$this->assertArrayHasKey( 'class', $attrs );
+		$this->assertStringContainsString( 'button', $attrs['class'] );
+	}
+
+	/** @testdox Getting all attributes should include button style class */
+	public function test_get_attributes_includes_style(): void {
+		$button = new Button( 'test' );
+		$attrs  = $button->get_attributes();
+		$this->assertArrayHasKey( 'class', $attrs );
+		$this->assertStringContainsString( 'pc-form__button', $attrs['class'] );
+	}
+
+	/** @testdox Getting class attribute with custom class added should merge with style */
+	public function test_get_attribute_class_with_custom(): void {
+		$button = new Button( 'test' );
+		$button->add_class( 'extra' );
+		$class = $button->get_attribute( 'class' );
+		$this->assertStringContainsString( 'pc-form__button', $class );
+		$this->assertStringContainsString( 'extra', $class );
+	}
 }

--- a/tests/Unit/Element/Test_Fields_Trait.php
+++ b/tests/Unit/Element/Test_Fields_Trait.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the Fields trait (tested through Form)
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Element;
+
+use WP_UnitTestCase;
+use Respect\Validation\Validator;
+use PinkCrab\Form_Components\Element\Form;
+use PinkCrab\Form_Components\Element\Group;
+use PinkCrab\Form_Components\Element\Nonce;
+use PinkCrab\Form_Components\Element\Raw_HTML;
+use PinkCrab\Form_Components\Element\Fieldset;
+use PinkCrab\Form_Components\Element\Field\Input\Text;
+use PinkCrab\Form_Components\Element\Field\Input\Email;
+use PinkCrab\Form_Components\Element\Field\Input\Number;
+use PinkCrab\Form_Components\Element\Field\Select;
+
+/**
+ * @group unit
+ * @group element
+ * @group fields
+ */
+class Test_Fields_Trait extends WP_UnitTestCase {
+
+	####################################################################
+	######                     ADD FIELD                          ######
+	####################################################################
+
+	/** @testdox It should be possible to add a field using the add_field method */
+	public function test_add_field(): void {
+		$form = new Form( 'test_form' );
+		$form->add_field( 'username', Text::class );
+		$this->assertTrue( $form->has_field( 'username' ) );
+		$field = $form->get_field( 'username' );
+		$this->assertInstanceOf( Text::class, $field );
+	}
+
+	/** @testdox It should be possible to add a field with a config callback */
+	public function test_add_field_with_config(): void {
+		$form = new Form( 'test_form' );
+		$form->add_field( 'username', Text::class, function( $field ) {
+			$field->label( 'Username' );
+			$field->required();
+			return $field;
+		} );
+		$field = $form->get_field( 'username' );
+		$this->assertInstanceOf( Text::class, $field );
+		$this->assertEquals( 'Username', $field->get_label() );
+		$this->assertTrue( $field->is_required() );
+	}
+
+	####################################################################
+	######                       FIELDS                          ######
+	####################################################################
+
+	/** @testdox It should be possible to add multiple fields using the fields method */
+	public function test_fields(): void {
+		$form = new Form( 'test_form' );
+		$form->fields(
+			new Text( 'name' ),
+			new Email( 'email' ),
+			new Number( 'age' )
+		);
+		$this->assertCount( 3, $form->get_fields() );
+		$this->assertTrue( $form->has_field( 'name' ) );
+		$this->assertTrue( $form->has_field( 'email' ) );
+		$this->assertTrue( $form->has_field( 'age' ) );
+	}
+
+	/** @testdox It should be possible to get all field names */
+	public function test_get_field_names(): void {
+		$form = new Form( 'test_form' );
+		$form->fields(
+			new Text( 'first_name' ),
+			new Text( 'last_name' )
+		);
+		$names = $form->get_field_names();
+		$this->assertContains( 'first_name', $names );
+		$this->assertContains( 'last_name', $names );
+	}
+
+	/** @testdox Getting a non-existent field should return null */
+	public function test_get_nonexistent_field(): void {
+		$form = new Form( 'test_form' );
+		$this->assertNull( $form->get_field( 'nonexistent' ) );
+	}
+
+	/** @testdox has_field should return false for non-existent fields */
+	public function test_has_field_false(): void {
+		$form = new Form( 'test_form' );
+		$this->assertFalse( $form->has_field( 'nonexistent' ) );
+	}
+
+	####################################################################
+	######                   NESTED FIELDS                       ######
+	####################################################################
+
+	/** @testdox It should be possible to get nested fields from a Group */
+	public function test_nested_fields_from_group(): void {
+		$form  = new Form( 'test_form' );
+		$group = new Group( 'address' );
+		$group->fields(
+			new Text( 'street' ),
+			new Text( 'city' )
+		);
+		$form->fields( $group );
+
+		// The form should be able to find the nested fields
+		$this->assertTrue( $form->has_field( 'street' ) );
+		$this->assertTrue( $form->has_field( 'city' ) );
+	}
+
+	/** @testdox get_nested_fields should return all fields flattened */
+	public function test_get_nested_fields(): void {
+		$form  = new Form( 'test_form' );
+		$group = new Group( 'group1' );
+		$group->fields(
+			new Text( 'nested_field' )
+		);
+		$form->fields(
+			new Text( 'top_field' ),
+			$group
+		);
+		$nested = $form->get_nested_fields();
+		$this->assertArrayHasKey( 'top_field', $nested );
+		$this->assertArrayHasKey( 'nested_field', $nested );
+	}
+
+	####################################################################
+	######                 VALIDATION RULES                      ######
+	####################################################################
+
+	/** @testdox It should be possible to add validation rules manually */
+	public function test_add_validation_rule(): void {
+		$form = new Form( 'test_form' );
+		$form->add_validation_rule( 'name', new Validator() );
+		$rules = $form->get_validation_rules();
+		$this->assertArrayHasKey( 'name', $rules );
+	}
+
+	/** @testdox Fields with validators should auto-register validation rules */
+	public function test_auto_register_validation_rules(): void {
+		$form = new Form( 'test_form' );
+		$text = new Text( 'username' );
+		$text->validator( new Validator() );
+		$form->fields( $text );
+		$rules = $form->get_validation_rules();
+		$this->assertArrayHasKey( 'username', $rules );
+	}
+
+	/** @testdox Fields without validators should not add validation rules */
+	public function test_no_auto_register_without_validator(): void {
+		$form = new Form( 'test_form' );
+		$form->fields( new Text( 'plain_field' ) );
+		$rules = $form->get_validation_rules();
+		$this->assertArrayNotHasKey( 'plain_field', $rules );
+	}
+
+	####################################################################
+	######                  STYLE CASCADE                        ######
+	####################################################################
+
+	/** @testdox Parent form style should cascade to child fields without explicit style */
+	public function test_style_cascade(): void {
+		$form = new Form( 'test_form' );
+		$text = new Text( 'name' );
+		$form->fields( $text );
+
+		// The child should inherit the parent's style
+		$field = $form->get_field( 'name' );
+		$this->assertNotNull( $field );
+	}
+}

--- a/tests/Unit/Element/Test_Fieldset.php
+++ b/tests/Unit/Element/Test_Fieldset.php
@@ -181,4 +181,97 @@ class Test_Fieldset extends WP_UnitTestCase {
 		$this->assertTrue( $fieldset->is_disabled() );
 		$this->assertCount( 2, $fieldset->get_fields() );
 	}
+
+	/** @testdox It should be possible to construct a Fieldset with a custom style */
+	public function test_custom_style(): void {
+		$style    = new Default_Style();
+		$fieldset = new Fieldset( 'test', $style );
+		$this->assertSame( $style, $fieldset->get_style() );
+	}
+
+	/** @testdox Getting wrapper class attribute should include element wrapper style */
+	public function test_get_wrapper_attribute_class(): void {
+		$fieldset = new Fieldset( 'test' );
+		$class    = $fieldset->get_wrapper_attribute( 'class' );
+		$this->assertStringContainsString( 'pc-form__element', $class );
+		$this->assertStringContainsString( 'fieldset', $class );
+	}
+
+	/** @testdox Getting wrapper class with custom class added should merge */
+	public function test_get_wrapper_attribute_class_with_custom(): void {
+		$fieldset = new Fieldset( 'test' );
+		$fieldset->add_wrapper_class( 'custom-class' );
+		$class = $fieldset->get_wrapper_attribute( 'class' );
+		$this->assertStringContainsString( 'custom-class', $class );
+		$this->assertStringContainsString( 'pc-form__element', $class );
+	}
+
+	/** @testdox It should be possible to get a single attribute via the base trait method */
+	public function test_get_attribute(): void {
+		$fieldset = new Fieldset( 'test' );
+		$this->assertNull( $fieldset->get_attribute( 'data-nope' ) );
+		$fieldset->attribute( 'data-foo', 'bar' );
+		$this->assertEquals( 'bar', $fieldset->get_attribute( 'data-foo' ) );
+	}
+
+	/** @testdox It should be possible to get all attributes via the base trait method */
+	public function test_get_attributes(): void {
+		$fieldset = new Fieldset( 'test' );
+		$fieldset->attribute( 'data-a', '1' );
+		$fieldset->attribute( 'data-b', '2' );
+		$attrs = $fieldset->get_attributes();
+		$this->assertIsArray( $attrs );
+		$this->assertArrayHasKey( 'data-a', $attrs );
+		$this->assertArrayHasKey( 'data-b', $attrs );
+	}
+
+	/** @testdox Adding a class when no class attribute exists should set it */
+	public function test_add_class_when_no_class_exists(): void {
+		$fieldset = new Fieldset( 'test' );
+		// Clear any existing class via reflection
+		$reflection = new \ReflectionClass( $fieldset );
+		$prop       = $reflection->getProperty( 'attributes' );
+		$prop->setAccessible( true );
+		$attrs = $prop->getValue( $fieldset );
+		unset( $attrs['class'] );
+		$prop->setValue( $fieldset, $attrs );
+
+		$fieldset->add_class( 'my-class' );
+		$this->assertEquals( 'my-class', $fieldset->get_attribute( 'class' ) );
+	}
+
+	/** @testdox Removing a class when no class attribute exists should not throw */
+	public function test_remove_class_when_no_class_exists(): void {
+		$fieldset = new Fieldset( 'test' );
+		// Clear any existing class via reflection
+		$reflection = new \ReflectionClass( $fieldset );
+		$prop       = $reflection->getProperty( 'attributes' );
+		$prop->setAccessible( true );
+		$attrs = $prop->getValue( $fieldset );
+		unset( $attrs['class'] );
+		$prop->setValue( $fieldset, $attrs );
+
+		$this->assertSame( $fieldset, $fieldset->remove_class( 'nope' ) );
+	}
+
+	/** @testdox Adding and removing classes should work via base trait */
+	public function test_add_and_remove_class(): void {
+		$fieldset = new Fieldset( 'test' );
+		// Clear any existing class via reflection
+		$reflection = new \ReflectionClass( $fieldset );
+		$prop       = $reflection->getProperty( 'attributes' );
+		$prop->setAccessible( true );
+		$attrs = $prop->getValue( $fieldset );
+		unset( $attrs['class'] );
+		$prop->setValue( $fieldset, $attrs );
+
+		$fieldset->add_class( 'foo' );
+		$fieldset->add_class( 'bar' );
+		$this->assertStringContainsString( 'foo', $fieldset->get_attribute( 'class' ) );
+		$this->assertStringContainsString( 'bar', $fieldset->get_attribute( 'class' ) );
+
+		$fieldset->remove_class( 'foo' );
+		$this->assertStringNotContainsString( 'foo', $fieldset->get_attribute( 'class' ) );
+		$this->assertStringContainsString( 'bar', $fieldset->get_attribute( 'class' ) );
+	}
 }

--- a/tests/Unit/Element/Test_Form.php
+++ b/tests/Unit/Element/Test_Form.php
@@ -305,4 +305,11 @@ class Test_Form extends WP_UnitTestCase {
 		$this->assertEquals( '<p>Footer</p>', $form->get_after() );
 		$this->assertCount( 4, $form->get_fields() );
 	}
+
+	/** @testdox It should be possible to construct a Form with a custom style */
+	public function test_custom_style(): void {
+		$style = new \PinkCrab\Form_Components\Style\Default_Style();
+		$form  = new Form( 'test', $style );
+		$this->assertSame( $style, $form->get_style() );
+	}
 }

--- a/tests/Unit/Element/Test_Group.php
+++ b/tests/Unit/Element/Test_Group.php
@@ -145,4 +145,11 @@ class Test_Group extends WP_UnitTestCase {
 		$group->add_wrapper_class( 'custom' );
 		$this->assertStringContainsString( 'custom', $group->get_wrapper_attribute( 'class' ) );
 	}
+
+	/** @testdox It should be possible to construct a Group with a custom style */
+	public function test_custom_style(): void {
+		$style = new \PinkCrab\Form_Components\Style\Default_Style();
+		$group = new Group( 'test', $style );
+		$this->assertSame( $style, $group->get_style() );
+	}
 }

--- a/tests/Unit/Element/Test_Raw_HTML.php
+++ b/tests/Unit/Element/Test_Raw_HTML.php
@@ -127,4 +127,19 @@ class Test_Raw_HTML extends WP_UnitTestCase {
 		$raw->wrapper_id( 'my-id' );
 		$this->assertEquals( 'my-id', $raw->get_wrapper_attribute( 'id' ) );
 	}
+
+	/** @testdox It should be possible to get all wrapper attributes */
+	public function test_get_wrapper_attributes(): void {
+		$raw = new Raw_HTML( 'test' );
+		$raw->wrapper_attribute( 'data-foo', 'bar' );
+		$attrs = $raw->get_wrapper_attributes();
+		$this->assertIsArray( $attrs );
+		$this->assertArrayHasKey( 'data-foo', $attrs );
+	}
+
+	/** @testdox Removing a wrapper class when none exist should not throw */
+	public function test_remove_wrapper_class_when_no_class(): void {
+		$raw = new Raw_HTML( 'test' );
+		$this->assertSame( $raw, $raw->remove_wrapper_class( 'nope' ) );
+	}
 }

--- a/tests/Unit/Element/Test_Validation_Trait.php
+++ b/tests/Unit/Element/Test_Validation_Trait.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the Validation trait
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Element;
+
+use WP_UnitTestCase;
+use Respect\Validation\Validator;
+use PinkCrab\Form_Components\Element\Field\Input\Text;
+
+/**
+ * @group unit
+ * @group element
+ * @group validation
+ */
+class Test_Validation_Trait extends WP_UnitTestCase {
+
+	/** @testdox A field should not have a validator by default */
+	public function test_no_validator_by_default(): void {
+		$text = new Text( 'test' );
+		$this->assertFalse( $text->has_validator() );
+		$this->assertNull( $text->get_validator() );
+	}
+
+	/** @testdox It should be possible to set a validator on a field */
+	public function test_set_validator(): void {
+		$text      = new Text( 'test' );
+		$validator = new Validator();
+		$text->validator( $validator );
+		$this->assertTrue( $text->has_validator() );
+		$this->assertSame( $validator, $text->get_validator() );
+	}
+
+	/** @testdox It should be possible to clear a validator by passing null */
+	public function test_clear_validator(): void {
+		$text      = new Text( 'test' );
+		$validator = new Validator();
+		$text->validator( $validator );
+		$this->assertTrue( $text->has_validator() );
+		$text->validator( null );
+		$this->assertFalse( $text->has_validator() );
+		$this->assertNull( $text->get_validator() );
+	}
+
+	/** @testdox The validator method should return the field for chaining */
+	public function test_validator_returns_self(): void {
+		$text   = new Text( 'test' );
+		$result = $text->validator( new Validator() );
+		$this->assertSame( $text, $result );
+	}
+}

--- a/tests/Unit/Module/Test_Form_Components_Module.php
+++ b/tests/Unit/Module/Test_Form_Components_Module.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the Form_Components module.
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Module;
+
+use WP_UnitTestCase;
+use PinkCrab\Perique\Interfaces\Module;
+use PinkCrab\Form_Components\Module\Form_Components;
+use PinkCrab\Form_Components\Component\Field\Input_Component;
+use PinkCrab\Form_Components\Component\Field\Label_Component;
+use PinkCrab\Form_Components\Component\Field\Select_Component;
+use PinkCrab\Form_Components\Component\Field\Raw_HTML_Component;
+use PinkCrab\Form_Components\Component\Field\Textarea_Component;
+use PinkCrab\Form_Components\Component\Field\Radio_Group_Component;
+use PinkCrab\Form_Components\Component\Field\Checkbox_Group_Component;
+use PinkCrab\Form_Components\Component\Field\Button_Component;
+use PinkCrab\Form_Components\Component\Field\Datalist_Component;
+use PinkCrab\Form_Components\Component\Field\Notification_Component;
+use PinkCrab\Form_Components\Component\Form\Form_Component;
+use PinkCrab\Form_Components\Component\Form\Group_Component;
+use PinkCrab\Form_Components\Component\Form\Fieldset_Component;
+use PinkCrab\Form_Components\Component\Partial\Nonce_Component;
+use PinkCrab\Form_Components\Component\Partial\Field_Wrapper_End;
+use PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start;
+use PinkCrab\Perique\Application\Hooks;
+
+/**
+ * @group unit
+ * @group module
+ */
+class Test_Form_Components_Module extends WP_UnitTestCase {
+
+	/** @testdox Form_Components should implement the Module interface */
+	public function test_implements_module(): void {
+		$module = new Form_Components();
+		$this->assertInstanceOf( Module::class, $module );
+	}
+
+	/** @testdox get_middleware should return null */
+	public function test_get_middleware_returns_null(): void {
+		$module = new Form_Components();
+		$this->assertNull( $module->get_middleware() );
+	}
+
+	/** @testdox The module constructor should register the component alias filter */
+	public function test_constructor_registers_filter(): void {
+		$module = new Form_Components();
+		$this->assertNotFalse( has_filter( Hooks::COMPONENT_ALIASES ) );
+	}
+
+	/** @testdox The component alias filter should add all form component aliases */
+	public function test_component_aliases_registered(): void {
+		// Remove any existing filters first
+		remove_all_filters( Hooks::COMPONENT_ALIASES );
+
+		$module = new Form_Components();
+
+		// Apply the filter with an empty array
+		$aliases = apply_filters( Hooks::COMPONENT_ALIASES, array() );
+
+		// Verify all expected component classes are registered
+		$this->assertArrayHasKey( Input_Component::class, $aliases );
+		$this->assertArrayHasKey( Textarea_Component::class, $aliases );
+		$this->assertArrayHasKey( Select_Component::class, $aliases );
+		$this->assertArrayHasKey( Raw_HTML_Component::class, $aliases );
+		$this->assertArrayHasKey( Checkbox_Group_Component::class, $aliases );
+		$this->assertArrayHasKey( Radio_Group_Component::class, $aliases );
+		$this->assertArrayHasKey( Field_Wrapper_Start::class, $aliases );
+		$this->assertArrayHasKey( Field_Wrapper_End::class, $aliases );
+		$this->assertArrayHasKey( Nonce_Component::class, $aliases );
+		$this->assertArrayHasKey( Label_Component::class, $aliases );
+		$this->assertArrayHasKey( Datalist_Component::class, $aliases );
+		$this->assertArrayHasKey( Button_Component::class, $aliases );
+		$this->assertArrayHasKey( Notification_Component::class, $aliases );
+		$this->assertArrayHasKey( Form_Component::class, $aliases );
+		$this->assertArrayHasKey( Group_Component::class, $aliases );
+		$this->assertArrayHasKey( Fieldset_Component::class, $aliases );
+	}
+
+	/** @testdox The template paths should point to existing files */
+	public function test_template_paths_exist(): void {
+		// Remove any existing filters first
+		remove_all_filters( Hooks::COMPONENT_ALIASES );
+
+		$module  = new Form_Components();
+		$aliases = apply_filters( Hooks::COMPONENT_ALIASES, array() );
+
+		foreach ( $aliases as $class => $path ) {
+			$this->assertFileExists( $path, "Template not found for {$class}: {$path}" );
+		}
+	}
+
+	/** @testdox The component aliases should merge with existing aliases */
+	public function test_component_aliases_merge_with_existing(): void {
+		// Remove any existing filters first
+		remove_all_filters( Hooks::COMPONENT_ALIASES );
+
+		$module = new Form_Components();
+
+		$existing = array( 'ExistingComponent' => '/path/to/template.php' );
+		$aliases  = apply_filters( Hooks::COMPONENT_ALIASES, $existing );
+
+		// Should keep existing and add new
+		$this->assertArrayHasKey( 'ExistingComponent', $aliases );
+		$this->assertArrayHasKey( Input_Component::class, $aliases );
+	}
+
+	/** @testdox pre_boot should be callable without errors */
+	public function test_pre_boot(): void {
+		$module = new Form_Components();
+		$module->pre_boot(
+			new \PinkCrab\Perique\Application\App_Config(),
+			new \PinkCrab\Loader\Hook_Loader(),
+			$this->createMock( \PinkCrab\Perique\Interfaces\DI_Container::class )
+		);
+		$this->assertTrue( true ); // No exception thrown
+	}
+
+	/** @testdox pre_register should be callable without errors */
+	public function test_pre_register(): void {
+		$module = new Form_Components();
+		$module->pre_register(
+			new \PinkCrab\Perique\Application\App_Config(),
+			new \PinkCrab\Loader\Hook_Loader(),
+			$this->createMock( \PinkCrab\Perique\Interfaces\DI_Container::class )
+		);
+		$this->assertTrue( true ); // No exception thrown
+	}
+
+	/** @testdox post_register should be callable without errors */
+	public function test_post_register(): void {
+		$module = new Form_Components();
+		$module->post_register(
+			new \PinkCrab\Perique\Application\App_Config(),
+			new \PinkCrab\Loader\Hook_Loader(),
+			$this->createMock( \PinkCrab\Perique\Interfaces\DI_Container::class )
+		);
+		$this->assertTrue( true ); // No exception thrown
+	}
+}

--- a/tests/Unit/Style/Test_Default_Style.php
+++ b/tests/Unit/Style/Test_Default_Style.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for Default_Style
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Style;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Style\Style;
+use PinkCrab\Form_Components\Style\Default_Style;
+
+/**
+ * @group unit
+ * @group style
+ */
+class Test_Default_Style extends WP_UnitTestCase {
+
+	/** @testdox Default_Style should implement the Style interface */
+	public function test_implements_style(): void {
+		$style = new Default_Style();
+		$this->assertInstanceOf( Style::class, $style );
+	}
+
+	/** @testdox form_class should return the expected value */
+	public function test_form_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'pc-form', $style->form_class() );
+	}
+
+	/** @testdox element_wrapper_class should return a format string */
+	public function test_element_wrapper_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'pc-form__element pc-form__element--%s', $style->element_wrapper_class() );
+	}
+
+	/** @testdox field_class should return a format string */
+	public function test_field_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'pc-form__element__field pc-form__element__field--%s', $style->field_class() );
+	}
+
+	/** @testdox notification_template should return a format string */
+	public function test_notification_template(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'notification-%s', $style->notification_template() );
+	}
+
+	/** @testdox notification_wrapper_class should return a format string */
+	public function test_notification_wrapper_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'pc-form__notification pc-form__notification--%s', $style->notification_wrapper_class() );
+	}
+
+	/** @testdox button_class should return the expected value */
+	public function test_button_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'pc-form__button', $style->button_class() );
+	}
+
+	/** @testdox field_control_class should return a format string */
+	public function test_field_control_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'form-control %s', $style->field_control_class() );
+	}
+
+	/** @testdox group_option_class should return a format string */
+	public function test_group_option_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( '%s__option', $style->group_option_class() );
+	}
+
+	/** @testdox label_class should return the expected value */
+	public function test_label_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'pc-form__label', $style->label_class() );
+	}
+
+	/** @testdox legend_class should return the expected value */
+	public function test_legend_class(): void {
+		$style = new Default_Style();
+		$this->assertEquals( 'pc-form__legend', $style->legend_class() );
+	}
+}

--- a/tests/Unit/Style/Test_Style_Provider.php
+++ b/tests/Unit/Style/Test_Style_Provider.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for Style_Provider
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Style;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Style\Style;
+use PinkCrab\Form_Components\Style\Default_Style;
+use PinkCrab\Form_Components\Style\Style_Provider;
+
+/**
+ * @group unit
+ * @group style
+ */
+class Test_Style_Provider extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		parent::tear_down();
+		// Reset to default style after each test
+		Style_Provider::set_default_style( Default_Style::class );
+	}
+
+	/** @testdox It should be possible to get the default style */
+	public function test_get_default_style(): void {
+		$style = Style_Provider::get_default_style();
+		$this->assertInstanceOf( Style::class, $style );
+		$this->assertInstanceOf( Default_Style::class, $style );
+	}
+
+	/** @testdox It should be possible to set a custom default style */
+	public function test_set_default_style(): void {
+		$custom_style = new class implements Style {
+			public function form_class(): string { return 'custom-form'; }
+			public function element_wrapper_class(): string { return 'custom-wrapper-%s'; }
+			public function field_class(): string { return 'custom-field-%s'; }
+			public function notification_template(): string { return 'custom-notification-%s'; }
+			public function notification_wrapper_class(): string { return 'custom-notification-wrapper-%s'; }
+			public function button_class(): string { return 'custom-button'; }
+			public function field_control_class(): string { return 'custom-control %s'; }
+			public function group_option_class(): string { return '%s__custom-option'; }
+			public function label_class(): string { return 'custom-label'; }
+			public function legend_class(): string { return 'custom-legend'; }
+		};
+
+		Style_Provider::set_default_style( get_class( $custom_style ) );
+		$style = Style_Provider::get_default_style();
+		$this->assertEquals( 'custom-form', $style->form_class() );
+	}
+
+	/** @testdox Setting a non-Style class should throw InvalidArgumentException */
+	public function test_set_invalid_style_throws(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Defined style must implement Style interface' );
+		Style_Provider::set_default_style( \stdClass::class );
+	}
+}

--- a/tests/Unit/Util/Test_Sanitize.php
+++ b/tests/Unit/Util/Test_Sanitize.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the Sanitize utility class
+ *
+ * @since 0.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Util;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Util\Sanitize;
+
+/**
+ * @group unit
+ * @group util
+ */
+class Test_Sanitize extends WP_UnitTestCase {
+
+	####################################################################
+	######                       TEXT                             ######
+	####################################################################
+
+	/** @testdox It should sanitize a text string */
+	public function test_text_string(): void {
+		$this->assertEquals( 'hello world', Sanitize::text( 'hello world' ) );
+	}
+
+	/** @testdox It should strip HTML tags from text */
+	public function test_text_strips_html(): void {
+		$this->assertStringNotContainsString( '<script>', Sanitize::text( '<script>alert("xss")</script>' ) );
+	}
+
+	/** @testdox It should handle numeric values as text */
+	public function test_text_numeric(): void {
+		$this->assertEquals( '42', Sanitize::text( 42 ) );
+		$this->assertEquals( '3.14', Sanitize::text( 3.14 ) );
+	}
+
+	####################################################################
+	######                     TEXTAREA                          ######
+	####################################################################
+
+	/** @testdox It should sanitize textarea content */
+	public function test_textarea(): void {
+		$this->assertEquals( "line 1\nline 2", Sanitize::textarea( "line 1\nline 2" ) );
+	}
+
+	/** @testdox It should strip HTML from textarea */
+	public function test_textarea_strips_html(): void {
+		$this->assertStringNotContainsString( '<script>', Sanitize::textarea( '<script>bad</script>text' ) );
+	}
+
+	####################################################################
+	######                        URL                            ######
+	####################################################################
+
+	/** @testdox It should sanitize a URL */
+	public function test_url(): void {
+		$this->assertEquals( 'http://example.com', Sanitize::url( 'http://example.com' ) );
+	}
+
+	/** @testdox It should handle non-string URL input */
+	public function test_url_numeric(): void {
+		$result = Sanitize::url( 123 );
+		$this->assertIsString( $result );
+	}
+
+	####################################################################
+	######                     HEX COLOR                         ######
+	####################################################################
+
+	/** @testdox It should sanitize a valid hex color */
+	public function test_hex_color_valid(): void {
+		$this->assertEquals( '#ff0000', Sanitize::hex_color( '#ff0000' ) );
+	}
+
+	/** @testdox It should sanitize a 3-character hex color */
+	public function test_hex_color_short(): void {
+		$this->assertEquals( '#f00', Sanitize::hex_color( '#f00' ) );
+	}
+
+	####################################################################
+	######                       EMAIL                           ######
+	####################################################################
+
+	/** @testdox It should sanitize a valid email */
+	public function test_email_valid(): void {
+		$this->assertEquals( 'test@example.com', Sanitize::email( 'test@example.com' ) );
+	}
+
+	/** @testdox It should handle non-string email input */
+	public function test_email_numeric(): void {
+		$result = Sanitize::email( 123 );
+		$this->assertIsString( $result );
+	}
+
+	####################################################################
+	######                      NUMBER                           ######
+	####################################################################
+
+	/** @testdox It should return 0 for null */
+	public function test_number_null(): void {
+		$this->assertSame( 0, Sanitize::number( null ) );
+	}
+
+	/** @testdox It should return an integer for whole numbers */
+	public function test_number_integer(): void {
+		$this->assertSame( 42, Sanitize::number( '42' ) );
+		$this->assertSame( 42, Sanitize::number( 42 ) );
+	}
+
+	/** @testdox It should return a float for decimal numbers */
+	public function test_number_float(): void {
+		$this->assertSame( 3.14, Sanitize::number( '3.14' ) );
+		$this->assertSame( 3.14, Sanitize::number( 3.14 ) );
+	}
+
+	/** @testdox It should handle string numbers */
+	public function test_number_string(): void {
+		$this->assertSame( 100, Sanitize::number( '100' ) );
+	}
+
+	####################################################################
+	######                       NOOP                            ######
+	####################################################################
+
+	/** @testdox Noop should pass through the value unchanged */
+	public function test_noop_string(): void {
+		$this->assertSame( 'hello', Sanitize::noop( 'hello' ) );
+	}
+
+	/** @testdox Noop should pass through numeric values unchanged */
+	public function test_noop_numeric(): void {
+		$this->assertSame( 42, Sanitize::noop( 42 ) );
+		$this->assertSame( 3.14, Sanitize::noop( 3.14 ) );
+	}
+
+	####################################################################
+	######                    CONSTANTS                          ######
+	####################################################################
+
+	/** @testdox All Sanitize constants should be callable */
+	public function test_constants_are_callable(): void {
+		$this->assertTrue( is_callable( Sanitize::TEXT ) );
+		$this->assertTrue( is_callable( Sanitize::TEXTAREA ) );
+		$this->assertTrue( is_callable( Sanitize::URL ) );
+		$this->assertTrue( is_callable( Sanitize::HEX_COLOR ) );
+		$this->assertTrue( is_callable( Sanitize::EMAIL ) );
+		$this->assertTrue( is_callable( Sanitize::NUMBER ) );
+		$this->assertTrue( is_callable( Sanitize::NOOP ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,9 @@ define('TEST_FIXTURES_DIR', __DIR__ . '/Fixtures');
 
 // Composer autoloader must be loaded before WP_PHPUNIT__DIR will be available
 require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// Load test stubs for external dependencies not installed.
+require_once __DIR__ . '/Fixtures/Mock_Objects/Validator_Stub.php';
 // Give access to tests_add_filter() function.
 require_once getenv('WP_PHPUNIT__DIR') . '/includes/functions.php';
 


### PR DESCRIPTION
This pull request adds new unit tests and test fixtures to improve test coverage and reliability for the Perique Form Components library. The main focus is on expanding test coverage for the component factory, input elements, and traits such as checked and disabled. Additionally, test stubs and mock objects are introduced to support testing scenarios without requiring external dependencies.

**Expanded Unit Test Coverage:**

* Added comprehensive tests for the `Component_Factory`, ensuring correct component instantiation and dispatching for all supported element types, including groups, fieldsets, and wrappers. Also tests edge cases such as unknown element types and attribute handling. [[1]](diffhunk://#diff-aaa7c83c2be30db48409f30649d9abd058aa6a3b28610774fa9c2446e1eeed47R15-R43) [[2]](diffhunk://#diff-aaa7c83c2be30db48409f30649d9abd058aa6a3b28610774fa9c2446e1eeed47R61-R251)
* Introduced unit tests for `Abstract_Input` methods, covering `tabindex`, `set_existing`, `get_type`, sanitization, and form style guard logic.
* Added tests for the `Checkbox` element, specifically for the `checked` and `disabled` traits, verifying their correct behavior.

**Test Fixtures and Stubs:**

* Added a mock element (`Element_With_Notification_Only`) that uses the `Notification` trait without `Form_Style`, to test guard clauses in notification components.
* Added a stub for `Respect\Validation\Validator` and its interface to allow tests to run without requiring the actual validation package.

**Documentation:**

* Added a Codecov badge to the `README.md` to display code coverage status.