### PR TITLE
adds a custom field with wrapper and further support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -141,3 +141,34 @@ coding_style:
             general:
                 use_tabs: true
                 size: 4
+        spaces:
+            around_operators:
+                concatenation: true
+            before_parentheses:
+                function_declaration: true
+                closure_definition: true
+                function_call: false
+                if: true
+                for: true
+                while: true
+                switch: true
+                catch: true
+            within:
+                function_call: true
+                function_declaration: true
+                if: true
+                for: true
+                while: true
+                switch: true
+                catch: true
+                type_cast: true
+            before_left_brace:
+                class: true
+                function: true
+                if: true
+                else: true
+                for: true
+                while: true
+                do: true
+                switch: true
+                try: true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -89,8 +89,6 @@ tools:
                         php_indent_sniff: true
                     xss:
                         escape_output_sniff: true
-                    wp:
-                        alternative_functions_sniff: false
                 generic:
                     code_analysis:
                         unused_function_parameter_sniff: true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -67,9 +67,7 @@ tools:
                     files:
                         file_name_sniff: false
                     php:
-                        yoda_conditions_sniff: false
                         discouraged_functions_sniff: true
-                        disallow_short_ternary_sniff: false
                     arrays:
                         array_declaration_sniff: true
                     classes:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,140 @@
+build:
+    environment:
+        php: 8.2
+    nodes:
+        analysis:
+            project_setup:
+                override:
+                    - 'composer install --no-interaction --prefer-dist'
+            tests:
+                override:
+                    - php-scrutinizer-run
+                    -
+                        command: phpcs-run
+                        use_website_config: true
+
+filter:
+    paths:
+        - 'src/*'
+    excluded_paths:
+        - 'tests/*'
+        - 'docs/*'
+        - 'docs-gen/*'
+        - 'node_modules/*'
+        - 'vendor/*'
+        - 'template/*'
+
+tools:
+    php_mess_detector:
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'template/*']
+        config:
+            unused_code_rules: { unused_formal_parameter: true }
+            controversial_rules: { superglobals: false }
+            design_rules: { exit_expression: false }
+    php_analyzer:
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'template/*']
+        config:
+            parameter_reference_check: { enabled: true }
+            checkstyle: { enabled: true, no_trailing_whitespace: true, naming: { enabled: true, local_variable: '^[a-z][a-zA-Z0-9_]*$', abstract_class_name: ^Abstract|Factory$, utility_class_name: 'Utils?$', constant_name: '^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$', property_name: '^[a-z][a-zA-Z0-9_]*$', method_name: '^(?:[a-z]|__)[a-zA-Z0-9_]*$', parameter_name: '^[a-z][a-zA-Z0-9_]*$', interface_name: '^[A-Z][a-zA-Z0-9_]*$', type_name: '^[A-Z][a-zA-Z0-9_]*$', exception_name: '^[A-Z][a-zA-Z0-9]*Exception$', isser_method_name: '^(?:is|has|should|may|supports|get|can)' } }
+            unreachable_code: { enabled: true }
+            check_access_control: { enabled: true }
+            typo_checks: { enabled: true }
+            check_variables: { enabled: true }
+            suspicious_code: { enabled: false, overriding_parameter: false, overriding_closure_use: false, parameter_closure_use_conflict: false, parameter_multiple_times: false, non_existent_class_in_instanceof_check: false, non_existent_class_in_catch_clause: false, assignment_of_null_return: false, non_commented_switch_fallthrough: false, non_commented_empty_catch_block: false, overriding_private_members: false, use_statement_alias_conflict: false, precedence_in_condition_assignment: false }
+            dead_assignments: { enabled: true }
+            verify_php_doc_comments: { enabled: true, parameters: true, return: true, suggest_more_specific_types: true, ask_for_return_if_not_inferrable: true, ask_for_param_type_annotation: true }
+            loops_must_use_braces: { enabled: false }
+            check_usage_context: { enabled: true, method_call_on_non_object: { enabled: true, ignore_null_pointer: true }, foreach: { value_as_reference: true, traversable: true }, missing_argument: true, argument_type_checks: lenient }
+            simplify_boolean_return: { enabled: false }
+            phpunit_checks: { enabled: false }
+            reflection_checks: { enabled: false }
+            precedence_checks: { enabled: true, assignment_in_condition: true, comparison_of_bit_result: true }
+            basic_semantic_checks: { enabled: true }
+            doc_comment_fixes: { enabled: false }
+            reflection_fixes: { enabled: false }
+            use_statement_fixes: { enabled: true, remove_unused: true, preserve_multiple: false, order_alphabetically: false }
+    php_code_sniffer:
+        command: 'phpcs -n -s -p -v'
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'template/*']
+        config:
+            tab_width: '4'
+            standard: WordPress-Extra
+            sniffs:
+                wordpress:
+                    files:
+                        file_name_sniff: false
+                    php:
+                        yoda_conditions_sniff: false
+                        discouraged_functions_sniff: true
+                        disallow_short_ternary_sniff: false
+                    arrays:
+                        array_declaration_sniff: true
+                    classes:
+                        valid_class_name_sniff: true
+                    formatting:
+                        multiple_statement_alignment_sniff: true
+                    functions:
+                        function_call_signature_sniff: true
+                        function_declaration_argument_spacing_sniff: true
+                    naming_conventions:
+                        valid_function_name_sniff: true
+                    objects:
+                        object_instantiation_sniff: true
+                    strings:
+                        double_quote_usage_sniff: true
+                    white_space:
+                        control_structure_spacing_sniff: true
+                        operator_spacing_sniff: true
+                        php_indent_sniff: true
+                    xss:
+                        escape_output_sniff: true
+                    wp:
+                        alternative_functions_sniff: false
+                generic:
+                    code_analysis:
+                        unused_function_parameter_sniff: true
+                    commenting:
+                        todo_sniff: true
+    sensiolabs_security_checker:
+        filter:
+            excluded_paths: ['tests/*', 'docs/*']
+    php_cpd:
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'template/*']
+    php_pdepend:
+        excluded_dirs:
+            - tests
+            - docs
+            - node_modules
+            - vendor
+            - template
+
+checks:
+    php:
+        fix_php_opening_tag: false
+        remove_php_closing_tag: false
+        one_class_per_file: false
+        side_effects_or_types: false
+        no_mixed_inline_html: false
+        require_braces_around_control_structures: false
+        php5_style_constructor: false
+        no_global_keyword: false
+        avoid_usage_of_logical_operators: false
+        psr2_class_declaration: false
+        no_underscore_prefix_in_properties: false
+        no_underscore_prefix_in_methods: false
+        blank_line_after_namespace_declaration: false
+        single_namespace_per_use: false
+        psr2_switch_declaration: false
+        psr2_control_structure_declaration: false
+        avoid_superglobals: false
+        security_vulnerabilities: false
+        no_exit: false
+        code_rating: true
+        duplication: true
+
+coding_style:
+    php: {  }

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,11 +1,14 @@
 build:
     environment:
         php: 8.2
+    dependencies:
+        override:
+            - 'composer install --no-interaction --prefer-dist'
     nodes:
         analysis:
             project_setup:
                 override:
-                    - 'composer install --no-interaction --prefer-dist'
+                    - 'true'
             tests:
                 override:
                     - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -136,4 +136,8 @@ checks:
         duplication: true
 
 coding_style:
-    php: {  }
+    php:
+        indentation:
+            general:
+                use_tabs: true
+                size: 4

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,118 +1,7 @@
-build:
-    environment:
-        php: 8.2
-    dependencies:
-        override:
-            - 'composer install --no-interaction --prefer-dist'
-    nodes:
-        analysis:
-            project_setup:
-                override:
-                    - 'true'
-            tests:
-                override:
-                    - php-scrutinizer-run
-                    -
-                        command: phpcs-run
-                        use_website_config: true
-
-filter:
-    paths:
-        - 'src/*'
-    excluded_paths:
-        - 'tests/*'
-        - 'docs/*'
-        - 'docs-gen/*'
-        - 'node_modules/*'
-        - 'vendor/*'
-        - 'template/*'
-
-tools:
-    php_mess_detector:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*', 'template/*']
-        config:
-            unused_code_rules: { unused_formal_parameter: true }
-            controversial_rules: { superglobals: false }
-            design_rules: { exit_expression: false }
-    php_analyzer:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*', 'template/*']
-        config:
-            parameter_reference_check: { enabled: true }
-            checkstyle: { enabled: true, no_trailing_whitespace: true, naming: { enabled: true, local_variable: '^[a-z][a-zA-Z0-9_]*$', abstract_class_name: ^Abstract|Factory$, utility_class_name: 'Utils?$', constant_name: '^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$', property_name: '^[a-z][a-zA-Z0-9_]*$', method_name: '^(?:[a-z]|__)[a-zA-Z0-9_]*$', parameter_name: '^[a-z][a-zA-Z0-9_]*$', interface_name: '^[A-Z][a-zA-Z0-9_]*$', type_name: '^[A-Z][a-zA-Z0-9_]*$', exception_name: '^[A-Z][a-zA-Z0-9]*Exception$', isser_method_name: '^(?:is|has|should|may|supports|get|can)' } }
-            unreachable_code: { enabled: true }
-            check_access_control: { enabled: true }
-            typo_checks: { enabled: true }
-            check_variables: { enabled: true }
-            suspicious_code: { enabled: false, overriding_parameter: false, overriding_closure_use: false, parameter_closure_use_conflict: false, parameter_multiple_times: false, non_existent_class_in_instanceof_check: false, non_existent_class_in_catch_clause: false, assignment_of_null_return: false, non_commented_switch_fallthrough: false, non_commented_empty_catch_block: false, overriding_private_members: false, use_statement_alias_conflict: false, precedence_in_condition_assignment: false }
-            dead_assignments: { enabled: true }
-            verify_php_doc_comments: { enabled: true, parameters: true, return: true, suggest_more_specific_types: true, ask_for_return_if_not_inferrable: true, ask_for_param_type_annotation: true }
-            loops_must_use_braces: { enabled: false }
-            check_usage_context: { enabled: true, method_call_on_non_object: { enabled: true, ignore_null_pointer: true }, foreach: { value_as_reference: true, traversable: true }, missing_argument: true, argument_type_checks: lenient }
-            simplify_boolean_return: { enabled: false }
-            phpunit_checks: { enabled: false }
-            reflection_checks: { enabled: false }
-            precedence_checks: { enabled: true, assignment_in_condition: true, comparison_of_bit_result: true }
-            basic_semantic_checks: { enabled: true }
-            doc_comment_fixes: { enabled: false }
-            reflection_fixes: { enabled: false }
-            use_statement_fixes: { enabled: true, remove_unused: true, preserve_multiple: false, order_alphabetically: false }
-    php_code_sniffer:
-        command: 'phpcs -n -s -p -v'
-        filter:
-            excluded_paths: ['tests/*', 'docs/*', 'template/*']
-        config:
-            tab_width: '4'
-            standard: WordPress-Extra
-            sniffs:
-                wordpress:
-                    files:
-                        file_name_sniff: false
-                    php:
-                        discouraged_functions_sniff: true
-                    arrays:
-                        array_declaration_sniff: true
-                    classes:
-                        valid_class_name_sniff: true
-                    formatting:
-                        multiple_statement_alignment_sniff: true
-                    functions:
-                        function_call_signature_sniff: true
-                        function_declaration_argument_spacing_sniff: true
-                    naming_conventions:
-                        valid_function_name_sniff: true
-                    objects:
-                        object_instantiation_sniff: true
-                    strings:
-                        double_quote_usage_sniff: true
-                    white_space:
-                        control_structure_spacing_sniff: true
-                        operator_spacing_sniff: true
-                        php_indent_sniff: true
-                    xss:
-                        escape_output_sniff: true
-                generic:
-                    code_analysis:
-                        unused_function_parameter_sniff: true
-                    commenting:
-                        todo_sniff: true
-    sensiolabs_security_checker:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*']
-    php_cpd:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*', 'template/*']
-    php_pdepend:
-        excluded_dirs:
-            - tests
-            - docs
-            - node_modules
-            - vendor
-            - template
-
 checks:
     php:
+        code_rating: true
+        duplication: true
         fix_php_opening_tag: false
         remove_php_closing_tag: false
         one_class_per_file: false
@@ -132,8 +21,56 @@ checks:
         avoid_superglobals: false
         security_vulnerabilities: false
         no_exit: false
-        code_rating: true
-        duplication: true
+
+build:
+    dependencies:
+        override:
+            - 'composer install --no-interaction --prefer-dist'
+    nodes:
+        analysis:
+            project_setup:
+                override:
+                    - 'true'
+            tests:
+                override:
+                    - php-scrutinizer-run
+
+tools:
+    php_analyzer:
+        enabled: true
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'template/*', 'node_modules/*', 'vendor/*']
+        config:
+            checkstyle:
+                enabled: true
+                naming:
+                    isser_method_name: ^.*$
+                    utility_class_name: ^.*$
+            doc_comment_fixes:
+                enabled: false
+            reflection_fixes:
+                enabled: false
+            use_statement_fixes:
+                enabled: false
+            simplify_boolean_return:
+                enabled: true
+    php_changetracking: true
+    php_cpd: true
+    php_cs_fixer: false
+    php_mess_detector: true
+    php_pdepend: true
+    sensiolabs_security_checker: true
+
+filter:
+    paths:
+        - 'src/*'
+    excluded_paths:
+        - 'tests/*'
+        - 'docs/*'
+        - 'docs-gen/*'
+        - 'node_modules/*'
+        - 'vendor/*'
+        - 'template/*'
 
 coding_style:
     php:
@@ -142,33 +79,7 @@ coding_style:
                 use_tabs: true
                 size: 4
         spaces:
+            before_parentheses:
+                closure_definition: true
             around_operators:
                 concatenation: true
-            before_parentheses:
-                function_declaration: true
-                closure_definition: true
-                function_call: false
-                if: true
-                for: true
-                while: true
-                switch: true
-                catch: true
-            within:
-                function_call: true
-                function_declaration: true
-                if: true
-                for: true
-                while: true
-                switch: true
-                catch: true
-                type_cast: true
-            before_left_brace:
-                class: true
-                function: true
-                if: true
-                else: true
-                for: true
-                while: true
-                do: true
-                switch: true
-                try: true

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ $this->component( Make::form( 'enquiry', fn( $f ) => $f
 | Button | `Element\Button` | `Make::button()` | [View](docs/fields/button.md) |
 | Form | `Element\Form` | `Make::form()` | [View](docs/fields/form.md) |
 | Fieldset | `Element\Fieldset` | `Make::fieldset()` | [View](docs/fields/fieldset.md) |
+| Custom Field | `Element\Custom_Field` | `Make::custom()` | [View](docs/fields/custom-field.md) |
 
 ****
 

--- a/docs/fields/custom-field.md
+++ b/docs/fields/custom-field.md
@@ -1,0 +1,212 @@
+# Custom Field
+
+Renders arbitrary HTML content with the full field treatment: wrapper div, label, notifications, style classes, before/after content.
+
+Use this when you need a custom-rendered field (colour pickers, date pickers, WYSIWYG editors, etc.) that still participates in the form's wrapper/label/notification system.
+
+**Class:** `PinkCrab\Form_Components\Element\Custom_Field`  
+**Make helper:** `Make::custom( 'name', fn(Custom_Field $f) => $f->... )`
+
+---
+
+## Basic Usage
+
+```php
+$this->component( new Custom_Field_Component(
+    Custom_Field::make( 'bio' )
+        ->label( 'Biography' )
+        ->content( '<div class="wysiwyg-editor" data-field="bio">Editor loads here</div>' )
+) );
+```
+
+---
+
+## Using Make Helper
+
+```php
+use PinkCrab\Form_Components\Util\Make;
+
+$this->component( Make::custom( 'widget', fn( $f ) => $f
+    ->label( 'My Widget' )
+    ->content( '<div class="custom-widget">...</div>' )
+) );
+```
+
+---
+
+## Methods
+
+### content( string $html )
+
+Sets the HTML content string to render in the field slot.
+
+```php
+Custom_Field::make( 'editor' )
+    ->label( 'Content' )
+    ->content( '<textarea class="wp-editor">Hello</textarea>' )
+```
+
+### content_callback( callable $callback )
+
+Sets a callable that receives the field instance and returns HTML. This takes priority over `content()` if both are set.
+
+```php
+Custom_Field::make( 'dynamic' )
+    ->label( 'Dynamic Field' )
+    ->content_callback( function( Custom_Field $field ) {
+        return sprintf(
+            '<input type="text" name="%s" value="%s" class="custom-input">',
+            esc_attr( $field->get_name() ),
+            esc_attr( $field->get_value() ?? '' )
+        );
+    } )
+```
+
+### get_content()
+
+Returns the rendered content. If a callback is set, it is called. Otherwise returns the string content.
+
+### has_content()
+
+Returns `true` if content (string or callback) has been set.
+
+---
+
+## Content Filtering (KSES)
+
+By default, content is filtered through `wp_kses_post()` which strips `<script>`, `<style>`, `<template>` tags and unrecognised attributes. You can customise this behaviour.
+
+### kses_rules( array $rules )
+
+Sets custom allowed HTML rules. Uses `wp_kses()` with the provided rules instead of `wp_kses_post()`.
+
+```php
+Custom_Field::make( 'rich_editor' )
+    ->content( '<div class="editor"><template id="tmpl">...</template></div>' )
+    ->kses_rules( array(
+        'div'      => array( 'class' => true, 'id' => true, 'data-*' => true ),
+        'template' => array( 'id' => true ),
+        'input'    => array( 'type' => true, 'name' => true, 'value' => true ),
+        'span'     => array( 'class' => true ),
+    ) )
+```
+
+### disable_kses()
+
+Disables kses filtering entirely. Content is rendered as-is. Use with caution - only when you trust the content source.
+
+```php
+Custom_Field::make( 'trusted' )
+    ->content( '<script>initWidget();</script><div id="widget"></div>' )
+    ->disable_kses()
+```
+
+### enable_kses()
+
+Re-enables kses filtering after it has been disabled.
+
+### is_kses_enabled()
+
+Returns `true` if kses filtering is active.
+
+### get_kses_rules()
+
+Returns the custom rules array, or `null` if using the default `wp_kses_post`.
+
+---
+
+## Shared Methods
+
+Custom_Field extends Field and uses the Label, Single_Value, and Notification traits, so it supports all common field methods:
+
+### label( string $label )
+
+Sets the visible label text above the field.
+
+```php
+Custom_Field::make( 'picker' )
+    ->label( 'Choose a colour' )
+    ->content( '<input type="color" name="picker">' )
+```
+
+### set_existing( mixed $value )
+
+Sets the current value on the field.
+
+```php
+Custom_Field::make( 'colour' )
+    ->set_existing( '#ff0000' )
+```
+
+### error_notification( string $message )
+
+Displays an error message below the field.
+
+```php
+Custom_Field::make( 'widget' )
+    ->label( 'Widget' )
+    ->content( '<div class="widget"></div>' )
+    ->error_notification( 'Widget configuration is invalid.' )
+```
+
+### before( string $html ) / after( string $html )
+
+HTML content before or after the field within the wrapper.
+
+### show_wrapper( bool $show = true )
+
+Controls whether the wrapping `<div>` is rendered.
+
+### id( string $id )
+
+Sets a custom HTML `id` on the field element.
+
+### wrapper_id( string $id )
+
+Sets a custom HTML `id` on the wrapper div.
+
+### add_class( string $class ) / add_wrapper_class( string $class )
+
+Adds CSS classes to the field or wrapper elements.
+
+### attribute( string $key, mixed $value )
+
+Sets an arbitrary HTML attribute.
+
+### sanitizer( callable $fn )
+
+Sets a sanitization callback for `set_existing()`.
+
+### validator( Validator $validator )
+
+Sets a Respect\Validation validator for server-side validation.
+
+### style( Style $style )
+
+Sets a custom style, overriding the default.
+
+---
+
+## Traits
+
+| Trait | Methods |
+|-------|---------|
+| Label | `label()`, `get_label()`, `has_label()` |
+| Single_Value | `value()`, `get_value()`, `has_value()` |
+| Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |
+
+---
+
+## Comparison with Raw_HTML
+
+| Feature | Raw_HTML | Custom_Field |
+|---------|----------|--------------|
+| Wrapper div | No | Yes |
+| Label | No | Yes |
+| Notifications | No | Yes |
+| Style classes | No | Yes |
+| Before/after in wrapper | No | Yes |
+| KSES filtering | `wp_kses_post` only | Configurable or disabled |
+| Participates in form validation | No | Yes |
+| Sanitizer support | No | Yes |
+| Use case | Simple HTML snippets (headings, dividers) | Custom interactive fields |

--- a/src/Component/Component_Factory.php
+++ b/src/Component/Component_Factory.php
@@ -45,6 +45,8 @@ use PinkCrab\Form_Components\Component\Field\Checkbox_Group_Component;
 use PinkCrab\Form_Components\Component\Field\Textarea_Component;
 use PinkCrab\Perique\Services\View\Component\Component;
 use PinkCrab\Form_Components\Element\Field\Input\Abstract_Input;
+use PinkCrab\Form_Components\Element\Custom_Field;
+use PinkCrab\Form_Components\Component\Field\Custom_Field_Component;
 use PinkCrab\Form_Components\Element\{Field, Group, Fieldset, Element, Button};
 use function PinkCrab\FunctionConstructors\Objects\isInstanceOf;
 
@@ -94,6 +96,9 @@ class Component_Factory {
 
 			case $element instanceof Textarea:
 				return $this->from_textarea( $element );
+
+			case $element instanceof Custom_Field:
+				return $this->from_custom_field( $element );
 
 			case $element instanceof Abstract_Input:
 				return $this->from_field( $element );
@@ -217,5 +222,15 @@ class Component_Factory {
 	 */
 	public function from_html( Raw_HTML $html ): Component {
 		return new Raw_HTML_Component( $html );
+	}
+
+	/**
+	 * Create a component from a Custom_Field element.
+	 *
+	 * @param Custom_Field $field
+	 * @return Component
+	 */
+	public function from_custom_field( Custom_Field $field ): Component {
+		return new Custom_Field_Component( $field );
 	}
 }

--- a/src/Component/Field/Custom_Field_Component.php
+++ b/src/Component/Field/Custom_Field_Component.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Custom Field Component
+ *
+ * Renders a custom HTML field with the full wrapper/label/notification treatment.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @package PinkCrab\Form
+ */
+
+namespace PinkCrab\Form_Components\Component\Field;
+
+use PinkCrab\Form_Components\Util\Attributes;
+use PinkCrab\Form_Components\Element\Custom_Field;
+use PinkCrab\Form_Components\Component\Field\Abstract_Field_Component;
+
+class Custom_Field_Component extends Abstract_Field_Component {
+
+	/** @var Custom_Field */
+	protected $field;
+
+	/** @var string */
+	protected $content;
+
+	/**
+	 * Creates an instance of the component.
+	 *
+	 * @param Custom_Field $field
+	 * @param array<string, string|int|float|null> $attributes
+	 */
+	public function __construct( Custom_Field $field, array $attributes = array() ) {
+		$this->field   = $field;
+		$this->content = $field->filter_content( $field->get_content() );
+
+		$this->set_attributes( Attributes::combine( $field->get_attributes(), $attributes, array( 'class' ) ) );
+
+		$this->before_field = $this->field->get_before();
+		$this->after_field  = $this->field->get_after();
+	}
+
+	/** @inheritDoc */
+	protected function base_attributes(): array {
+		return array(
+			'class' => sprintf( $this->field->get_style()->field_control_class(), 'custom-field' ),
+		);
+	}
+}

--- a/src/Element/Custom_Field.php
+++ b/src/Element/Custom_Field.php
@@ -1,0 +1,194 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Custom Field element.
+ *
+ * A field that renders arbitrary HTML content but with the full field treatment:
+ * wrapper div, label, notification, style classes, before/after, sanitizer, validator.
+ *
+ * Supports custom wp_kses rules for content filtering. If no rules are provided,
+ * defaults to wp_kses_post rules. Pass an empty array to skip kses filtering entirely.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @package PinkCrab\Form
+ */
+
+namespace PinkCrab\Form_Components\Element;
+
+use PinkCrab\Form_Components\Element\Field;
+use PinkCrab\Form_Components\Element\Field\Attribute\Label;
+use PinkCrab\Form_Components\Element\Field\Attribute\Single_Value;
+use PinkCrab\Form_Components\Element\Field\Attribute\Notification;
+
+class Custom_Field extends Field {
+
+	use Label, Single_Value, Notification;
+
+	/**
+	 * The HTML content to render in the field slot.
+	 *
+	 * @var string
+	 */
+	protected $content = '';
+
+	/**
+	 * Optional callable that receives this field and returns HTML.
+	 *
+	 * @var callable|null
+	 */
+	protected $content_callback = null;
+
+	/**
+	 * Custom wp_kses allowed HTML rules.
+	 * null = use wp_kses_post (default)
+	 * array = use custom rules with wp_kses
+	 *
+	 * @var array<string, array<string, bool>>|null
+	 */
+	protected $kses_rules = null;
+
+	/**
+	 * Whether kses filtering is enabled.
+	 *
+	 * @var bool
+	 */
+	protected $kses_enabled = true;
+
+	/** @inheritDoc */
+	public function get_type(): string {
+		return 'custom_field';
+	}
+
+	/** @inheritDoc */
+	public function set_existing( $value ): self {
+		$this->value( $value );
+		return $this;
+	}
+
+	/**
+	 * Sets the HTML content string.
+	 *
+	 * @param string $content
+	 * @return static
+	 */
+	public function content( string $content ): self {
+		$this->content = $content;
+		return $this;
+	}
+
+	/**
+	 * Sets a callable that receives this field and returns HTML.
+	 *
+	 * @param callable $callback fn(Custom_Field): string
+	 * @return static
+	 */
+	public function content_callback( callable $callback ): self {
+		$this->content_callback = $callback;
+		return $this;
+	}
+
+	/**
+	 * Gets the rendered content.
+	 *
+	 * If a callback is set, it takes priority over the string content.
+	 *
+	 * @return string
+	 */
+	public function get_content(): string {
+		if ( null !== $this->content_callback ) {
+			return call_user_func( $this->content_callback, $this );
+		}
+		return $this->content;
+	}
+
+	/**
+	 * Checks if content has been set (string or callback).
+	 *
+	 * @return bool
+	 */
+	public function has_content(): bool {
+		return '' !== $this->content || null !== $this->content_callback;
+	}
+
+	/**
+	 * Sets custom wp_kses rules for content filtering.
+	 *
+	 * @param array<string, array<string, bool>> $rules
+	 * @return static
+	 */
+	public function kses_rules( array $rules ): self {
+		$this->kses_rules = $rules;
+		return $this;
+	}
+
+	/**
+	 * Gets the kses rules. Returns null if using default wp_kses_post.
+	 *
+	 * @return array<string, array<string, bool>>|null
+	 */
+	public function get_kses_rules(): ?array {
+		return $this->kses_rules;
+	}
+
+	/**
+	 * Disables kses filtering entirely.
+	 *
+	 * @return static
+	 */
+	public function disable_kses(): self {
+		$this->kses_enabled = false;
+		return $this;
+	}
+
+	/**
+	 * Enables kses filtering.
+	 *
+	 * @return static
+	 */
+	public function enable_kses(): self {
+		$this->kses_enabled = true;
+		return $this;
+	}
+
+	/**
+	 * Checks if kses filtering is enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_kses_enabled(): bool {
+		return $this->kses_enabled;
+	}
+
+	/**
+	 * Filters the content through kses rules.
+	 *
+	 * @param string $content
+	 * @return string
+	 */
+	public function filter_content( string $content ): string {
+		if ( ! $this->kses_enabled ) {
+			return $content;
+		}
+
+		if ( null !== $this->kses_rules ) {
+			return wp_kses( $content, $this->kses_rules );
+		}
+
+		return wp_kses_post( $content );
+	}
+}

--- a/src/Element/Field/Input/Password.php
+++ b/src/Element/Field/Input/Password.php
@@ -30,7 +30,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Pattern, Autocomplete, Dis
 
 class Password extends Abstract_Input {
 
-	use Autocomplete, Length, Pattern, Placeholder, Read_Only, Size,  Disabled, Required;
+	use Autocomplete, Length, Pattern, Placeholder, Read_Only, Size, Disabled, Required;
 
 	/** @inheritDoc */
 	protected $input_type = 'password';

--- a/src/Element/Field/Input/Search.php
+++ b/src/Element/Field/Input/Search.php
@@ -27,7 +27,7 @@ namespace PinkCrab\Form_Components\Element\Field\Input;
 
 use PinkCrab\Form_Components\Util\Sanitize;
 use PinkCrab\Form_Components\Element\Field\Input\Abstract_Input;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Single_Value, Placeholder, Read_Only, Required,Input_Mode, Spellcheck};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Single_Value, Placeholder, Read_Only, Required, Input_Mode, Spellcheck};
 
 class Search extends Abstract_Input {
 

--- a/src/Element/Field/Input/Tel.php
+++ b/src/Element/Field/Input/Tel.php
@@ -27,7 +27,7 @@ namespace PinkCrab\Form_Components\Element\Field\Input;
 
 use PinkCrab\Form_Components\Util\Sanitize;
 use PinkCrab\Form_Components\Element\Field\Input\Abstract_Input;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Size, Placeholder, Read_Only, Required,Input_Mode, Spellcheck};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Size, Placeholder, Read_Only, Required, Input_Mode, Spellcheck};
 
 class Tel extends Abstract_Input {
 

--- a/src/Element/Field/Input/Text.php
+++ b/src/Element/Field/Input/Text.php
@@ -27,7 +27,7 @@ namespace PinkCrab\Form_Components\Element\Field\Input;
 
 use PinkCrab\Form_Components\Util\Sanitize;
 use PinkCrab\Form_Components\Element\Field\Input\Abstract_Input;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Single_Value, Placeholder, Read_Only, Required,Input_Mode, Size, Spellcheck};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Single_Value, Placeholder, Read_Only, Required, Input_Mode, Size, Spellcheck};
 
 class Text extends Abstract_Input {
 

--- a/src/Element/Field/Input/Url.php
+++ b/src/Element/Field/Input/Url.php
@@ -27,7 +27,7 @@ namespace PinkCrab\Form_Components\Element\Field\Input;
 
 use PinkCrab\Form_Components\Util\Sanitize;
 use PinkCrab\Form_Components\Element\Field\Input\Abstract_Input;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Single_Value, Placeholder, Read_Only, Required,Input_Mode, Size, Spellcheck};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Autocomplete, Pattern, Datalist, Disabled, Length, Single_Value, Placeholder, Read_Only, Required, Input_Mode, Size, Spellcheck};
 
 class Url extends Abstract_Input {
 

--- a/src/Module/Form_Components.php
+++ b/src/Module/Form_Components.php
@@ -47,6 +47,7 @@ use PinkCrab\Form_Components\Component\Form\Fieldset_Component;
 use PinkCrab\Form_Components\Component\Partial\Nonce_Component;
 use PinkCrab\Form_Components\Component\Field\Datalist_Component;
 use PinkCrab\Form_Components\Component\Field\Notification_Component;
+use PinkCrab\Form_Components\Component\Field\Custom_Field_Component;
 use PinkCrab\Form_Components\Component\Partial\Field_Wrapper_End;
 use PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start;
 
@@ -86,6 +87,7 @@ class Form_Components implements Module {
 					Form_Component::class           => $this->resolve_template_path( 'form/form.php' ),
 					Group_Component::class          => $this->resolve_template_path( 'partial/group.php' ),
 					Fieldset_Component::class       => $this->resolve_template_path( 'form/fieldset.php' ),
+					Custom_Field_Component::class   => $this->resolve_template_path( 'field/custom-field.php' ),
 				);
 				return array_merge( $aliases, $custom_aliases );
 			},

--- a/src/Util/Make.php
+++ b/src/Util/Make.php
@@ -33,6 +33,8 @@ use PinkCrab\Form_Components\Element\Nonce;
 use PinkCrab\Form_Components\Element\Button;
 use PinkCrab\Form_Components\Element\Raw_HTML;
 use PinkCrab\Form_Components\Element\Fieldset;
+use PinkCrab\Form_Components\Element\Custom_Field;
+use PinkCrab\Form_Components\Component\Field\Custom_Field_Component;
 use PinkCrab\Form_Components\Element\Field\Select;
 use PinkCrab\Form_Components\Element\Field\Textarea;
 use PinkCrab\Form_Components\Element\Field\Input\Tel;
@@ -402,5 +404,17 @@ class Make {
 	public static function fieldset( string $name, ?callable $config = null ): Component {
 		$element = Fieldset::make( $name );
 		return new Fieldset_Component( $config ? $config( $element ) : $element );
+	}
+
+	/**
+	 * Custom field element.
+	 *
+	 * @param string $name
+	 * @param callable|null $config fn(Custom_Field): Custom_Field
+	 * @return Component
+	 */
+	public static function custom( string $name, ?callable $config = null ): Component {
+		$element = Custom_Field::make( $name );
+		return new Custom_Field_Component( $config ? $config( $element ) : $element );
 	}
 }

--- a/template/component/field/custom-field.php
+++ b/template/component/field/custom-field.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * The Custom Field component template.
+ *
+ * Renders arbitrary HTML content with the full field treatment:
+ * wrapper, label, notification, before/after.
+ *
+ * @package Perique\form-fields
+ *
+ * // Expected Variables
+ * @var Custom_Field $field
+ * @var string $content
+ * @var string $before_field
+ * @var string $after_field
+ * @var string $field_attributes
+ * @var string $wrapper_attributes
+ * @var bool $show_wrapper
+ */
+
+use function PinkCrab\FunctionConstructors\Objects\usesTrait;
+?>
+<?php if ( $show_wrapper ) : ?>
+	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes, $before_field ) ); ?>
+<?php endif; ?>
+	<?php if ( $field->has_label() ) : ?>
+		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Label_Component( $field->get_label(), $field->get_name(), $field->get_style()->label_class() ) ); ?>
+	<?php endif; ?>
+
+	<?php echo $content; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, filtered through kses in component. ?>
+
+	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Notification::class )( $field ) && $field->has_notification() ) : ?>
+		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>
+	<?php endif; ?>
+
+<?php if ( $show_wrapper ) : ?>
+	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_End( $after_field ) ); ?>
+<?php endif; ?>

--- a/tests/Unit/Element/Test_Custom_Field.php
+++ b/tests/Unit/Element/Test_Custom_Field.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the Custom_Field Element
+ *
+ * @since 2.1.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Element;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Element\Custom_Field;
+use PinkCrab\Form_Components\Element\Element;
+use PinkCrab\Form_Components\Style\Style;
+use PinkCrab\Form_Components\Style\Default_Style;
+use PinkCrab\Form_Components\Component\Component_Factory;
+use PinkCrab\Form_Components\Component\Field\Custom_Field_Component;
+use PinkCrab\Perique\Services\View\Component\Component;
+
+/**
+ * @group unit
+ * @group element
+ * @group custom_field
+ */
+class Test_Custom_Field extends WP_UnitTestCase {
+
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+
+	/** @inheritDoc */
+	public function get_class_under_test(): string {
+		return Custom_Field::class;
+	}
+
+	####################################################################
+	######                     FIELD BASICS                      ######
+	####################################################################
+
+	/** @testdox Custom_Field should implement the Element interface */
+	public function test_implements_element(): void {
+		$field = new Custom_Field( 'test' );
+		$this->assertInstanceOf( Element::class, $field );
+	}
+
+	/** @testdox Custom_Field should return type of custom_field */
+	public function test_get_type(): void {
+		$field = new Custom_Field( 'test' );
+		$this->assertEquals( 'custom_field', $field->get_type() );
+	}
+
+	/** @testdox Custom_Field should be creatable via make */
+	public function test_static_make(): void {
+		$field = Custom_Field::make( 'test' );
+		$this->assertInstanceOf( Custom_Field::class, $field );
+	}
+
+	/** @testdox Custom_Field should have a default style */
+	public function test_default_style(): void {
+		$field = new Custom_Field( 'test' );
+		$this->assertInstanceOf( Style::class, $field->get_style() );
+	}
+
+	####################################################################
+	######                      CONTENT                          ######
+	####################################################################
+
+	/** @testdox It should be possible to set and get content as a string */
+	public function test_content_string(): void {
+		$field = new Custom_Field( 'test' );
+		$this->assertEquals( '', $field->get_content() );
+		$this->assertFalse( $field->has_content() );
+
+		$field->content( '<div class="picker">Custom Widget</div>' );
+		$this->assertEquals( '<div class="picker">Custom Widget</div>', $field->get_content() );
+		$this->assertTrue( $field->has_content() );
+	}
+
+	/** @testdox It should be possible to set content via a callable */
+	public function test_content_callback(): void {
+		$field = new Custom_Field( 'my_field' );
+		$field->content_callback( function( Custom_Field $f ) {
+			return '<input type="text" name="' . esc_attr( $f->get_name() ) . '">';
+		} );
+		$this->assertTrue( $field->has_content() );
+		$this->assertStringContainsString( 'my_field', $field->get_content() );
+	}
+
+	/** @testdox Callback should take priority over string content */
+	public function test_callback_priority(): void {
+		$field = new Custom_Field( 'test' );
+		$field->content( 'string content' );
+		$field->content_callback( function() {
+			return 'callback content';
+		} );
+		$this->assertEquals( 'callback content', $field->get_content() );
+	}
+
+	/** @testdox Content method should return self for chaining */
+	public function test_content_returns_self(): void {
+		$field = new Custom_Field( 'test' );
+		$this->assertSame( $field, $field->content( 'html' ) );
+	}
+
+	/** @testdox Content callback method should return self for chaining */
+	public function test_content_callback_returns_self(): void {
+		$field = new Custom_Field( 'test' );
+		$this->assertSame( $field, $field->content_callback( function() { return ''; } ) );
+	}
+
+	####################################################################
+	######                     KSES RULES                        ######
+	####################################################################
+
+	/** @testdox By default kses should be enabled with wp_kses_post rules */
+	public function test_default_kses(): void {
+		$field = new Custom_Field( 'test' );
+		$this->assertTrue( $field->is_kses_enabled() );
+		$this->assertNull( $field->get_kses_rules() );
+	}
+
+	/** @testdox It should be possible to set custom kses rules */
+	public function test_custom_kses_rules(): void {
+		$rules = array(
+			'div'    => array( 'class' => true, 'id' => true ),
+			'span'   => array( 'class' => true ),
+			'input'  => array( 'type' => true, 'name' => true, 'value' => true ),
+			'script' => array(),
+		);
+		$field = new Custom_Field( 'test' );
+		$result = $field->kses_rules( $rules );
+		$this->assertSame( $field, $result );
+		$this->assertEquals( $rules, $field->get_kses_rules() );
+	}
+
+	/** @testdox Custom kses rules should filter content through wp_kses */
+	public function test_filter_with_custom_rules(): void {
+		$field = new Custom_Field( 'test' );
+		$field->kses_rules( array(
+			'div'  => array( 'class' => true ),
+			'span' => array(),
+		) );
+		$filtered = $field->filter_content( '<div class="ok"><script>bad</script><span>good</span></div>' );
+		$this->assertStringNotContainsString( '<script>', $filtered );
+		$this->assertStringContainsString( '<div class="ok">', $filtered );
+		$this->assertStringContainsString( '<span>good</span>', $filtered );
+	}
+
+	/** @testdox Default kses should use wp_kses_post */
+	public function test_filter_with_default_kses(): void {
+		$field    = new Custom_Field( 'test' );
+		$filtered = $field->filter_content( '<div class="ok"><script>bad</script></div>' );
+		$this->assertStringNotContainsString( '<script>', $filtered );
+		$this->assertStringContainsString( '<div class="ok">', $filtered );
+	}
+
+	/** @testdox It should be possible to disable kses entirely */
+	public function test_disable_kses(): void {
+		$field = new Custom_Field( 'test' );
+		$field->disable_kses();
+		$this->assertFalse( $field->is_kses_enabled() );
+
+		$raw      = '<script>alert("hi")</script>';
+		$filtered = $field->filter_content( $raw );
+		$this->assertEquals( $raw, $filtered );
+	}
+
+	/** @testdox It should be possible to re-enable kses after disabling */
+	public function test_enable_kses(): void {
+		$field = new Custom_Field( 'test' );
+		$field->disable_kses();
+		$this->assertFalse( $field->is_kses_enabled() );
+		$field->enable_kses();
+		$this->assertTrue( $field->is_kses_enabled() );
+	}
+
+	####################################################################
+	######                    SET EXISTING                        ######
+	####################################################################
+
+	/** @testdox set_existing should set the value */
+	public function test_set_existing(): void {
+		$field = new Custom_Field( 'test' );
+		$field->set_existing( 'some value' );
+		$this->assertEquals( 'some value', $field->get_value() );
+	}
+
+	####################################################################
+	######                     LABEL TRAIT                        ######
+	####################################################################
+
+	/** @testdox It should be possible to set a label */
+	public function test_label(): void {
+		$field = new Custom_Field( 'test' );
+		$field->label( 'My Custom Field' );
+		$this->assertTrue( $field->has_label() );
+		$this->assertEquals( 'My Custom Field', $field->get_label() );
+	}
+
+	####################################################################
+	######                  NOTIFICATION TRAIT                    ######
+	####################################################################
+
+	/** @testdox It should be possible to set notifications */
+	public function test_notification(): void {
+		$field = new Custom_Field( 'test' );
+		$field->error_notification( 'This field is required' );
+		$this->assertTrue( $field->has_notification() );
+		$this->assertEquals( 'This field is required', $field->get_notification() );
+		$this->assertEquals( 'error', $field->get_notification_type() );
+	}
+
+	####################################################################
+	######               COMPONENT FACTORY                       ######
+	####################################################################
+
+	/** @testdox Component_Factory should dispatch Custom_Field correctly */
+	public function test_factory_from_element(): void {
+		$field     = new Custom_Field( 'test' );
+		$component = Component_Factory::instance()->from_element( $field );
+		$this->assertInstanceOf( Custom_Field_Component::class, $component );
+	}
+
+	/** @testdox Component_Factory from_custom_field should work */
+	public function test_factory_from_custom_field(): void {
+		$field     = new Custom_Field( 'test' );
+		$component = Component_Factory::instance()->from_custom_field( $field );
+		$this->assertInstanceOf( Custom_Field_Component::class, $component );
+	}
+
+	####################################################################
+	######                    COMPONENT                          ######
+	####################################################################
+
+	/** @testdox Custom_Field_Component should store filtered content */
+	public function test_component_stores_content(): void {
+		$field = new Custom_Field( 'test' );
+		$field->content( '<div>Hello</div>' );
+		$component  = new Custom_Field_Component( $field );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'content' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'Hello', $prop->getValue( $component ) );
+	}
+
+	/** @testdox Custom_Field_Component should set before/after from field */
+	public function test_component_before_after(): void {
+		$field = new Custom_Field( 'test' );
+		$field->before( '<p>Before</p>' );
+		$field->after( '<p>After</p>' );
+		$component  = new Custom_Field_Component( $field );
+		$reflection = new \ReflectionClass( $component );
+
+		$before = $reflection->getProperty( 'before_field' );
+		$before->setAccessible( true );
+		$this->assertEquals( '<p>Before</p>', $before->getValue( $component ) );
+
+		$after = $reflection->getProperty( 'after_field' );
+		$after->setAccessible( true );
+		$this->assertEquals( '<p>After</p>', $after->getValue( $component ) );
+	}
+
+	/** @testdox Custom_Field_Component should include base class in field_attributes */
+	public function test_component_base_attributes(): void {
+		$field      = new Custom_Field( 'test' );
+		$component  = new Custom_Field_Component( $field );
+		$reflection = new \ReflectionClass( $component );
+
+		$prop = $reflection->getProperty( 'field_attributes' );
+		$prop->setAccessible( true );
+		$this->assertStringContainsString( 'custom-field', $prop->getValue( $component ) );
+	}
+
+	####################################################################
+	######                    FLUENT API                          ######
+	####################################################################
+
+	/** @testdox The fluent API should work for building a custom field */
+	public function test_fluent_api(): void {
+		$field = Custom_Field::make( 'widget' )
+			->label( 'My Widget' )
+			->content( '<div class="widget">Content</div>' )
+			->before( '<section>' )
+			->after( '</section>' )
+			->error_notification( 'Required' )
+			->kses_rules( array( 'div' => array( 'class' => true ) ) );
+
+		$this->assertEquals( 'widget', $field->get_name() );
+		$this->assertEquals( 'My Widget', $field->get_label() );
+		$this->assertTrue( $field->has_content() );
+		$this->assertEquals( 'error', $field->get_notification_type() );
+		$this->assertNotNull( $field->get_kses_rules() );
+	}
+}

--- a/tests/Unit/Module/Test_Form_Components_Module.php
+++ b/tests/Unit/Module/Test_Form_Components_Module.php
@@ -24,6 +24,7 @@ use PinkCrab\Form_Components\Component\Field\Checkbox_Group_Component;
 use PinkCrab\Form_Components\Component\Field\Button_Component;
 use PinkCrab\Form_Components\Component\Field\Datalist_Component;
 use PinkCrab\Form_Components\Component\Field\Notification_Component;
+use PinkCrab\Form_Components\Component\Field\Custom_Field_Component;
 use PinkCrab\Form_Components\Component\Form\Form_Component;
 use PinkCrab\Form_Components\Component\Form\Group_Component;
 use PinkCrab\Form_Components\Component\Form\Fieldset_Component;
@@ -83,6 +84,7 @@ class Test_Form_Components_Module extends WP_UnitTestCase {
 		$this->assertArrayHasKey( Form_Component::class, $aliases );
 		$this->assertArrayHasKey( Group_Component::class, $aliases );
 		$this->assertArrayHasKey( Fieldset_Component::class, $aliases );
+		$this->assertArrayHasKey( Custom_Field_Component::class, $aliases );
 	}
 
 	/** @testdox The template paths should point to existing files */

--- a/tests/Unit/Util/Test_Make.php
+++ b/tests/Unit/Util/Test_Make.php
@@ -22,6 +22,7 @@ use PinkCrab\Form_Components\Component\Field\Checkbox_Group_Component;
 use PinkCrab\Form_Components\Component\Field\Radio_Group_Component;
 use PinkCrab\Form_Components\Component\Form\Form_Component;
 use PinkCrab\Form_Components\Component\Form\Fieldset_Component;
+use PinkCrab\Form_Components\Component\Field\Custom_Field_Component;
 use PinkCrab\Form_Components\Component\Partial\Nonce_Component;
 use PinkCrab\Perique\Services\View\Component\Component;
 
@@ -190,6 +191,17 @@ class Test_Make extends WP_UnitTestCase {
 		$this->assertInstanceOf( Fieldset_Component::class, $component );
 	}
 
+	/** @testdox Make::custom() returns a Custom_Field_Component */
+	public function test_custom(): void {
+		$this->assertInstanceOf( Custom_Field_Component::class, Make::custom( 'widget' ) );
+	}
+
+	/** @testdox Make::custom() accepts a config callable */
+	public function test_custom_with_config(): void {
+		$component = Make::custom( 'widget', fn( $f ) => $f->label( 'My Widget' )->content( '<div>Hi</div>' ) );
+		$this->assertInstanceOf( Custom_Field_Component::class, $component );
+	}
+
 	/** @testdox All Make methods return instances of Component */
 	public function test_all_return_component(): void {
 		$this->assertInstanceOf( Component::class, Make::text( 'a' ) );
@@ -200,5 +212,6 @@ class Test_Make extends WP_UnitTestCase {
 		$this->assertInstanceOf( Component::class, Make::raw_html( 'f' ) );
 		$this->assertInstanceOf( Component::class, Make::form( 'g' ) );
 		$this->assertInstanceOf( Component::class, Make::fieldset( 'h' ) );
+		$this->assertInstanceOf( Component::class, Make::custom( 'i' ) );
 	}
 }


### PR DESCRIPTION
## Summary

- Added new `Custom_Field` element for rendering arbitrary HTML with full field treatment (wrapper, label, notifications, kses filtering)

## New: Custom_Field Element

A new field type for embedding custom HTML within the form component system. Unlike `Raw_HTML` (which renders bare HTML), `Custom_Field` gets the full wrapper/label/notification treatment.

```php
Custom_Field::make( 'my_widget' )
    ->label( 'Pick a thing' )
    ->content( '<div class="custom-picker">...</div>' )
    ->error_notification( 'Required field' )
    ->kses_rules( [ 'div' => [ 'class' => true ] ] )
```

Supports configurable `wp_kses` rules (defaults to `wp_kses_post`, can be customised or disabled entirely).

### Files Added
- `src/Element/Custom_Field.php` - Element class with content, content_callback, kses rules
- `src/Component/Field/Custom_Field_Component.php` - Component class
- `template/component/field/custom-field.php` - Template with wrapper/label/notification
- `tests/Unit/Element/Test_Custom_Field.php` - Full test coverage
- `docs/fields/custom-field.md` - Documentation

### Files Modified
- `src/Component/Component_Factory.php` - Added `from_custom_field()` dispatch
- `src/Module/Form_Components.php` - Registered template alias
- `src/Util/Make.php` - Added `Make::custom()` helper

