### PR TITLE
Uniform rendering for single or groups or checkbox or radio inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,5 +251,6 @@ $this->component( Make::form( 'enquiry', fn( $f ) => $f
 
 ## Change Log
 
+* 2.1.2 - Fixed label/input accessibility, wrapper class duplication and unnecessary `list` attribute rendering.
 * 2.1.1 - Added Custom_Field element for rendering arbitrary HTML with full field treatment (wrapper, label, notifications, configurable kses filtering)
 * 2.1.0 - Initial release for Perique 2.1.*

--- a/src/Component/Field/Input_Component.php
+++ b/src/Component/Field/Input_Component.php
@@ -61,9 +61,16 @@ class Input_Component extends Abstract_Field_Component {
 			'class' => sprintf( $this->field->get_style()->field_control_class(), "{$this->input_type}-input" ),
 		);
 
-		// If field uses the datalist trait and passed attribute doesnt include list.
+		// Auto-generate id from name if not explicitly set.
+		if ( ! $this->field->has_attribute( 'id' ) ) {
+			$attributes['id'] = $this->field->get_name();
+		}
+
+		// If field uses the datalist trait and has datalist items configured.
 		if ( usesTrait( Datalist::class )( $this->field )
 		&& method_exists( $this->field, 'get_datalist_key' )
+		&& method_exists( $this->field, 'has_datalist_items' )
+		&& $this->field->has_datalist_items()
 		) {
 			$attributes['list'] = $this->field->get_datalist_key();
 		}

--- a/src/Element/Field_Traits/Wrapper_Attributes.php
+++ b/src/Element/Field_Traits/Wrapper_Attributes.php
@@ -124,17 +124,20 @@ trait Wrapper_Attributes {
 	 * @return static
 	 */
 	public function add_wrapper_class( string $class_name ): self {
-		$classes = $this->get_wrapper_attribute( 'class' );
+		$classes = $this->wrapper_attributes['class'] ?? null;
 		if ( ! $classes ) {
-			return $this->wrapper_attribute( 'class', Esc::attribute( $class_name ) );
+			$this->wrapper_attributes['class'] = Esc::attribute( $class_name );
+			return $this;
 		}
 
-		$classes = explode( ' ', Esc::attribute( $classes ) );
-		if ( ! in_array( $class_name, $classes, true ) ) {
-			$classes[] = Esc::attribute( $class_name );
+		$classes      = explode( ' ', (string) $classes );
+		$escaped_name = Esc::attribute( $class_name );
+		if ( ! in_array( $escaped_name, $classes, true ) ) {
+			$classes[] = $escaped_name;
 		}
 
-		return $this->wrapper_attribute( 'class', implode( ' ', array_map( array( Esc::class, 'attribute' ), $classes ) ) );
+		$this->wrapper_attributes['class'] = implode( ' ', $classes );
+		return $this;
 	}
 
 	/**
@@ -144,17 +147,19 @@ trait Wrapper_Attributes {
 	 * @return static
 	 */
 	public function remove_wrapper_class( string $class_name ): self {
-		$classes = $this->get_wrapper_attribute( 'class' );
+		$classes = $this->wrapper_attributes['class'] ?? null;
 		if ( ! $classes ) {
 			return $this;
 		}
 
-		$classes = explode( ' ', Esc::attribute( $classes ) );
-		if ( in_array( $class_name, $classes, true ) ) {
-			$classes = array_diff( $classes, array( $class_name ) );
+		$classes      = explode( ' ', (string) $classes );
+		$escaped_name = Esc::attribute( $class_name );
+		if ( in_array( $escaped_name, $classes, true ) ) {
+			$classes = array_diff( $classes, array( $escaped_name ) );
 		}
 
-		return $this->wrapper_attribute( 'class', implode( ' ', array_map( array( Esc::class, 'attribute' ), $classes ) ) );
+		$this->wrapper_attributes['class'] = implode( ' ', $classes );
+		return $this;
 	}
 
 

--- a/tests/Unit/Element/Shared_Field_Cases.php
+++ b/tests/Unit/Element/Shared_Field_Cases.php
@@ -429,6 +429,60 @@ trait Shared_Field_Cases {
 		$this->assertEquals( 1, substr_count( $field->get_wrapper_attribute( 'class' ), 'test' ) );
 	}
 
+	/**
+	 * @testdox [Shared::WrapperAttributes] Adding multiple wrapper classes should not cause double or triple escaping of class values.
+	 * @see https://github.com/Pink-Crab/Perique-Form-Components/issues/16
+	 */
+	public function test_add_wrapper_class_no_double_escaping(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$field->add_wrapper_class( 'custom-one' );
+		$field->add_wrapper_class( 'custom-two' );
+		$field->add_wrapper_class( 'custom-three' );
+
+		$result = $field->get_wrapper_attribute( 'class' );
+		$this->assertEquals( 1, substr_count( $result, 'custom-one' ), 'custom-one should appear exactly once' );
+		$this->assertEquals( 1, substr_count( $result, 'custom-two' ), 'custom-two should appear exactly once' );
+		$this->assertEquals( 1, substr_count( $result, 'custom-three' ), 'custom-three should appear exactly once' );
+		$this->assertStringContainsString( 'custom-one custom-two custom-three', $result, 'Added classes should appear in order without escaping artifacts' );
+	}
+
+	/**
+	 * @testdox [Shared::WrapperAttributes] Adding duplicate wrapper classes should result in a clean class string without escaped duplicates.
+	 * @see https://github.com/Pink-Crab/Perique-Form-Components/issues/16
+	 */
+	public function test_add_wrapper_class_duplicates_no_escaping_artifacts(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		// The default style already adds pc-form__element, adding it again should not duplicate.
+		$field->add_wrapper_class( 'pc-form__element' );
+		$field->add_wrapper_class( 'pc-form__element' );
+
+		$result = $field->get_wrapper_attribute( 'class' );
+		$this->assertEquals( 1, substr_count( $result, 'pc-form__element ' ), 'pc-form__element should appear only once as a distinct class (not duplicated by escaping)' );
+	}
+
+	/**
+	 * @testdox [Shared::WrapperAttributes] Removing a wrapper class should produce a clean class string without escaping artifacts.
+	 * @see https://github.com/Pink-Crab/Perique-Form-Components/issues/16
+	 */
+	public function test_remove_wrapper_class_no_double_escaping(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$field->add_wrapper_class( 'custom-one' );
+		$field->add_wrapper_class( 'custom-two' );
+		$field->add_wrapper_class( 'custom-three' );
+		$field->remove_wrapper_class( 'custom-two' );
+
+		$result = $field->get_wrapper_attribute( 'class' );
+		$this->assertEquals( 1, substr_count( $result, 'custom-one' ), 'custom-one should remain' );
+		$this->assertEquals( 0, substr_count( $result, 'custom-two' ), 'custom-two should be removed' );
+		$this->assertEquals( 1, substr_count( $result, 'custom-three' ), 'custom-three should remain' );
+	}
+
 	/** @testdox [Shared::WrapperAttributes] It should be possible remove a class by its values from wrapper attributes. */
 	public function test_remove_wrapper_class_by_name(): void {
 		$class = $this->get_class_under_test();


### PR DESCRIPTION
This pull request focuses on improving the handling of wrapper class attributes for form fields, ensuring that class values are not double-escaped or duplicated, and that class removal is clean. Additionally, it enhances the logic for generating input field attributes. Comprehensive unit tests have been added to verify these behaviors.

**Wrapper class attribute handling improvements:**

* Refactored `add_wrapper_class` and `remove_wrapper_class` methods in `Wrapper_Attributes.php` to prevent double-escaping and duplication of class names, and to ensure proper removal of classes without leaving escaping artifacts. [[1]](diffhunk://#diff-5fb53ee6fd20338f9c9c9cd5f337a267275cc87d7227bbaf98118a962a99feb4L127-R140) [[2]](diffhunk://#diff-5fb53ee6fd20338f9c9c9cd5f337a267275cc87d7227bbaf98118a962a99feb4L147-R162)

**Input field attribute enhancements:**

* Updated `Input_Component.php` to auto-generate the `id` attribute from the field name if not explicitly set, and improved datalist support by ensuring the `list` attribute is only set when datalist items are present.

**Testing improvements:**

* Added multiple unit tests in `Shared_Field_Cases.php` to confirm that wrapper classes are added without double-escaping, duplicates are avoided, and removal leaves a clean class string. These tests directly address issues reported in the project's issue tracker.

Closing #16 