### PR TITLE
Fix/allow optional end error order on fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "analyse": "vendor/bin/phpstan analyse src -l8",
         "sniff": "./vendor/bin/phpcs src/ -v",
         "all": "composer coverage && composer analyse && composer sniff",
-        "test:application": "vendor/bin/phpunit --colors=always --testdox --group=application"
+        "test:application": "vendor/bin/phpunit --colors=always --testdox --group=application",
+        "e2e": "WP_BASE_URL=http://localhost:57892 npm run test:e2e"
     },
     "prefer-stable": true,
     "minimum-stability": "dev",

--- a/docs/fields/checkbox-group.md
+++ b/docs/fields/checkbox-group.md
@@ -364,6 +364,26 @@ Checkbox_Group::make( 'interests' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the checkbox options.
+
+```php
+Checkbox_Group::make( 'interests' )
+    ->label( 'Interests' )
+    ->pre_description( 'Select all that apply.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the checkbox options, before any notification.
+
+```php
+Checkbox_Group::make( 'interests' )
+    ->label( 'Interests' )
+    ->post_description( 'You can change these later.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the checkbox group within the wrapper.
@@ -593,3 +613,4 @@ Checkbox_Group::make( 'interests' )
 | Options | `options()`, `get_options()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |
 | Disabled | `disabled()`, `is_disabled()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |

--- a/docs/fields/checkbox.md
+++ b/docs/fields/checkbox.md
@@ -285,6 +285,26 @@ Checkbox::make( 'optional' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Checkbox::make( 'agree' )
+    ->label( 'I agree to the terms' )
+    ->pre_description( 'Please review the terms before agreeing.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Checkbox::make( 'agree' )
+    ->label( 'I agree to the terms' )
+    ->post_description( 'You can withdraw consent at any time.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -582,5 +602,6 @@ Checkbox::make( 'agree' )->style( new Default_Style() )
 | Single_Value | `value()`, `get_value()`, `has_value()` |
 | Checked | `checked()`, `is_checked()` |
 | Disabled | `disabled()`, `is_disabled()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |
 | Form_Style | `style()`, `get_style()`, `has_explicit_style()` |

--- a/docs/fields/color.md
+++ b/docs/fields/color.md
@@ -326,6 +326,26 @@ Color::make( 'info_color' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Color::make( 'brand_color' )
+    ->label( 'Brand Colour' )
+    ->pre_description( 'Pick your brand colour.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Color::make( 'brand_color' )
+    ->label( 'Brand Colour' )
+    ->post_description( 'Used across all pages.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.

--- a/docs/fields/color.md
+++ b/docs/fields/color.md
@@ -647,4 +647,5 @@ Color::make( 'color' )->style( new Default_Style() )
 | Disabled | `disabled()`, `is_disabled()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/custom-field.md
+++ b/docs/fields/custom-field.md
@@ -149,6 +149,26 @@ Custom_Field::make( 'widget' )
     ->error_notification( 'Widget configuration is invalid.' )
 ```
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the custom content.
+
+```php
+Custom_Field::make( 'preview' )
+    ->label( 'Preview' )
+    ->pre_description( 'This is a preview of your content.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the custom content, before any notification.
+
+```php
+Custom_Field::make( 'preview' )
+    ->label( 'Preview' )
+    ->post_description( 'Content will be sanitized on save.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the field within the wrapper.
@@ -194,6 +214,7 @@ Sets a custom style, overriding the default.
 | Label | `label()`, `get_label()`, `has_label()` |
 | Single_Value | `value()`, `get_value()`, `has_value()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 
 ---
 

--- a/docs/fields/date.md
+++ b/docs/fields/date.md
@@ -451,6 +451,26 @@ Date::make( 'info_date' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Date::make( 'birthday' )
+    ->label( 'Date of Birth' )
+    ->pre_description( 'Select your date of birth.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Date::make( 'birthday' )
+    ->label( 'Date of Birth' )
+    ->post_description( 'Format: YYYY-MM-DD' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -750,4 +770,5 @@ Date::make( 'date' )->style( new Default_Style() )
 | Read_Only | `readonly()`, `is_read_only()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/datetime.md
+++ b/docs/fields/datetime.md
@@ -549,6 +549,26 @@ Datetime::make( 'info_event' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Datetime::make( 'event_start' )
+    ->label( 'Event Start' )
+    ->pre_description( 'Select the event date and time.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Datetime::make( 'event_start' )
+    ->label( 'Event Start' )
+    ->post_description( 'All times are in your local timezone.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -848,4 +868,5 @@ Datetime::make( 'event_start' )->style( new Default_Style() )
 | Read_Only | `readonly()`, `is_read_only()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/email.md
+++ b/docs/fields/email.md
@@ -476,6 +476,26 @@ Email::make( 'info_email' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Email::make( 'email' )
+    ->label( 'Email Address' )
+    ->pre_description( 'We will never share your email.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Email::make( 'email' )
+    ->label( 'Email Address' )
+    ->post_description( 'Used for account recovery only.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -781,5 +801,6 @@ Email::make( 'email' )->style( new Default_Style() )
 | Size | `size()`, `get_size()`, `has_size()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Multiple | `multiple()`, `is_multiple()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |
 | Form_Style | `style()`, `get_style()`, `has_explicit_style()` |

--- a/docs/fields/fieldset.md
+++ b/docs/fields/fieldset.md
@@ -255,6 +255,32 @@ Fieldset::make( 'disabled_section' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description displayed after the legend but before the child fields.
+
+```php
+Fieldset::make( 'personal' )
+    ->legend( 'Personal Details' )
+    ->pre_description( 'Please fill in your personal information.' )
+    ->fields(
+        Text::make( 'name' )->label( 'Name' ),
+    )
+```
+
+### post_description( string $description )
+
+Sets a description displayed after the child fields.
+
+```php
+Fieldset::make( 'personal' )
+    ->legend( 'Personal Details' )
+    ->post_description( 'All fields are required.' )
+    ->fields(
+        Text::make( 'name' )->label( 'Name' ),
+    )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the fieldset's child elements, rendered inside the `<fieldset>` tag (after the legend).
@@ -650,3 +676,4 @@ Fieldset::make( 'address' )
 | Fields | `fields()`, `add_field()`, `get_fields()`, `get_field()`, `has_field()`, `get_field_names()`, `get_nested_fields()`, `add_validation_rule()`, `get_validation_rules()` |
 | Form_Style | `style()`, `get_style()`, `has_explicit_style()` |
 | Disabled | `disabled()`, `is_disabled()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |

--- a/docs/fields/file.md
+++ b/docs/fields/file.md
@@ -309,6 +309,26 @@ File::make( 'info_upload' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+File::make( 'upload' )
+    ->label( 'Upload File' )
+    ->pre_description( 'Select a file to upload.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+File::make( 'upload' )
+    ->label( 'Upload File' )
+    ->post_description( 'Accepted formats: PNG, JPG, PDF. Max 5MB.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -597,4 +617,5 @@ File::make( 'upload' )->style( new Default_Style() )
 | Multiple | `multiple()`, `is_multiple()` |
 | Disabled | `disabled()`, `is_disabled()` |
 | Required | `required()`, `is_required()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/hidden.md
+++ b/docs/fields/hidden.md
@@ -283,6 +283,24 @@ Hidden::make( 'action' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Hidden::make( 'form_id' )
+    ->pre_description( 'Internal form identifier.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Hidden::make( 'form_id' )
+    ->post_description( 'Auto-generated value.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper. Only relevant if `show_wrapper(true)` has been called.
@@ -530,4 +548,5 @@ Hidden::make( 'user_id' )->style( new Default_Style() )
 |-------|---------|
 | Label | `label()`, `get_label()`, `has_label()` |
 | Single_Value | `value()`, `get_value()`, `has_value()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/month.md
+++ b/docs/fields/month.md
@@ -466,6 +466,26 @@ Month::make( 'info_month' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Month::make( 'birth_month' )
+    ->label( 'Birth Month' )
+    ->pre_description( 'Select your birth month.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Month::make( 'birth_month' )
+    ->label( 'Birth Month' )
+    ->post_description( 'Format: YYYY-MM' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -766,4 +786,5 @@ Month::make( 'birth_month' )->style( new Default_Style() )
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Input_Mode | `inputmode()`, `get_inputmode()`, `has_inputmode()`, `clear_inputmode()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/number.md
+++ b/docs/fields/number.md
@@ -457,6 +457,26 @@ Number::make( 'info_qty' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Number::make( 'quantity' )
+    ->label( 'Quantity' )
+    ->pre_description( 'Enter the number of items.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Number::make( 'quantity' )
+    ->label( 'Quantity' )
+    ->post_description( 'Must be between 1 and 100.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -756,4 +776,5 @@ Number::make( 'quantity' )->style( new Default_Style() )
 | Read_Only | `readonly()`, `is_read_only()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/password.md
+++ b/docs/fields/password.md
@@ -395,6 +395,26 @@ Password::make( 'pw_info' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Password::make( 'password' )
+    ->label( 'Password' )
+    ->pre_description( 'Choose a strong password.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Password::make( 'password' )
+    ->label( 'Password' )
+    ->post_description( 'Must contain at least 8 characters.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -726,4 +746,5 @@ Password::make( 'password' )
 | Length | `minlength()`, `maxlength()`, `get_min_length()`, `get_max_length()` |
 | Size | `size()`, `get_size()`, `has_size()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/radio-group.md
+++ b/docs/fields/radio-group.md
@@ -374,6 +374,26 @@ Radio_Group::make( 'plan' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the radio options.
+
+```php
+Radio_Group::make( 'priority' )
+    ->label( 'Priority' )
+    ->pre_description( 'Choose one option.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the radio options, before any notification.
+
+```php
+Radio_Group::make( 'priority' )
+    ->label( 'Priority' )
+    ->post_description( 'This affects response time.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the radio group within the wrapper.
@@ -604,3 +624,4 @@ Radio_Group::make( 'plan' )
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |
 | Disabled | `disabled()`, `is_disabled()` |
 | Required | `required()`, `is_required()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |

--- a/docs/fields/radio.md
+++ b/docs/fields/radio.md
@@ -295,6 +295,26 @@ Radio::make( 'plan' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Radio::make( 'plan' )
+    ->label( 'Premium' )
+    ->pre_description( 'Our most popular plan.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Radio::make( 'plan' )
+    ->label( 'Premium' )
+    ->post_description( 'Includes all features and priority support.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -594,5 +614,6 @@ Radio::make( 'plan' )->style( new Default_Style() )
 | Single_Value | `value()`, `get_value()`, `has_value()` |
 | Checked | `checked()`, `is_checked()` |
 | Disabled | `disabled()`, `is_disabled()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |
 | Form_Style | `style()`, `get_style()`, `has_explicit_style()` |

--- a/docs/fields/range.md
+++ b/docs/fields/range.md
@@ -413,6 +413,26 @@ Range::make( 'info_vol' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Range::make( 'volume' )
+    ->label( 'Volume' )
+    ->pre_description( 'Adjust the volume level.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Range::make( 'volume' )
+    ->label( 'Volume' )
+    ->post_description( 'Drag the slider to set volume.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper. Useful for showing min/max labels alongside the slider.
@@ -713,4 +733,5 @@ Range::make( 'volume' )->style( new Default_Style() )
 | Required | `required()`, `is_required()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/search.md
+++ b/docs/fields/search.md
@@ -493,6 +493,26 @@ Search::make( 'query_info' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Search::make( 'query' )
+    ->label( 'Search' )
+    ->pre_description( 'Search across all content.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Search::make( 'query' )
+    ->label( 'Search' )
+    ->post_description( 'Use quotes for exact match.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -826,4 +846,5 @@ Search::make( 'query' )
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Input_Mode | `inputmode()`, `get_input_mode()`, `has_input_mode()` |
 | Spellcheck | `spellcheck()`, `is_spellcheck()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/select.md
+++ b/docs/fields/select.md
@@ -549,6 +549,26 @@ Select::make( 'country' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the select.
+
+```php
+Select::make( 'country' )
+    ->label( 'Country' )
+    ->pre_description( 'Where are you based?' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the select, before any notification.
+
+```php
+Select::make( 'country' )
+    ->label( 'Country' )
+    ->post_description( 'Used for shipping calculations.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the select within the wrapper.
@@ -880,3 +900,4 @@ Select::make( 'country' )
 | Multiple | `multiple()`, `is_multiple()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Size | `size()`, `get_size()`, `has_size()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |

--- a/docs/fields/tel.md
+++ b/docs/fields/tel.md
@@ -511,6 +511,26 @@ Tel::make( 'phone_info' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Tel::make( 'phone' )
+    ->label( 'Phone Number' )
+    ->pre_description( 'Include your country code.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Tel::make( 'phone' )
+    ->label( 'Phone Number' )
+    ->post_description( 'e.g. +44 7700 900000' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -845,4 +865,5 @@ Tel::make( 'phone' )
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Input_Mode | `inputmode()`, `get_input_mode()`, `has_input_mode()` |
 | Spellcheck | `spellcheck()`, `is_spellcheck()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/text.md
+++ b/docs/fields/text.md
@@ -501,6 +501,26 @@ Text::make( 'name_info' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Text::make( 'username' )
+    ->label( 'Username' )
+    ->pre_description( 'Choose a unique username.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Text::make( 'username' )
+    ->label( 'Username' )
+    ->post_description( 'Must be between 3 and 20 characters.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -836,4 +856,5 @@ Text::make( 'field' )
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Input_Mode | `inputmode()`, `get_input_mode()`, `has_input_mode()` |
 | Spellcheck | `spellcheck()`, `is_spellcheck()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/textarea.md
+++ b/docs/fields/textarea.md
@@ -449,6 +449,26 @@ Textarea::make( 'bio' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the textarea.
+
+```php
+Textarea::make( 'bio' )
+    ->label( 'Biography' )
+    ->pre_description( 'Tell us about yourself.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the textarea, before any notification.
+
+```php
+Textarea::make( 'bio' )
+    ->label( 'Biography' )
+    ->post_description( 'Maximum 500 characters.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the textarea within the wrapper.
@@ -764,3 +784,4 @@ Textarea::make( 'bio' )
 | Length | `minlength()`, `maxlength()`, `get_min_length()`, `get_max_length()` |
 | Spellcheck | `spellcheck()`, `is_spellcheck()` |
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |

--- a/docs/fields/time.md
+++ b/docs/fields/time.md
@@ -562,6 +562,26 @@ Time::make( 'info_time' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Time::make( 'start_time' )
+    ->label( 'Start Time' )
+    ->pre_description( 'Select your preferred time.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Time::make( 'start_time' )
+    ->label( 'Start Time' )
+    ->post_description( 'All times are in UTC.' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -863,4 +883,5 @@ Time::make( 'start_time' )->style( new Default_Style() )
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Input_Mode | `inputmode()`, `get_inputmode()`, `has_inputmode()`, `clear_inputmode()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/url.md
+++ b/docs/fields/url.md
@@ -515,6 +515,26 @@ Url::make( 'url_info' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Url::make( 'website' )
+    ->label( 'Website' )
+    ->pre_description( 'Your public profile URL.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Url::make( 'website' )
+    ->label( 'Website' )
+    ->post_description( 'Must start with https://' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -849,4 +869,5 @@ Url::make( 'website' )
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Input_Mode | `inputmode()`, `get_input_mode()`, `has_input_mode()` |
 | Spellcheck | `spellcheck()`, `is_spellcheck()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/docs/fields/week.md
+++ b/docs/fields/week.md
@@ -466,6 +466,26 @@ Week::make( 'info_week' )
 ```
 </details>
 
+### pre_description( string $description )
+
+Sets a description or hint displayed before the input.
+
+```php
+Week::make( 'delivery_week' )
+    ->label( 'Delivery Week' )
+    ->pre_description( 'Select your preferred delivery week.' )
+```
+
+### post_description( string $description )
+
+Sets a description or help text displayed after the input, before any notification.
+
+```php
+Week::make( 'delivery_week' )
+    ->label( 'Delivery Week' )
+    ->post_description( 'Format: YYYY-Wnn (e.g. 2026-W26)' )
+```
+
 ### before( string $html ) / after( string $html )
 
 HTML content before or after the input within the wrapper.
@@ -771,4 +791,5 @@ Week::make( 'delivery_week' )->style( new Default_Style() )
 | Autocomplete | `autocomplete()`, `get_autocomplete()`, `has_autocomplete()` |
 | Input_Mode | `inputmode()`, `get_inputmode()`, `has_inputmode()`, `clear_inputmode()` |
 | Datalist | `datalist_items()`, `get_datalist_key()`, `get_datalist_items()` |
+| Description | `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, `has_post_description()` |
 | Notification | `error_notification()`, `warning_notification()`, `success_notification()`, `info_notification()` |

--- a/src/Component/Form/Fieldset_Component.php
+++ b/src/Component/Form/Fieldset_Component.php
@@ -54,6 +54,15 @@ class Fieldset_Component extends Component {
 	/** @var string */
 	protected $after;
 
+	/** @var string|null */
+	protected $pre_description;
+
+	/** @var string|null */
+	protected $post_description;
+
+	/** @var string */
+	protected $description_class;
+
 	/**
 	 * @param Fieldset $fieldset
 	 */
@@ -73,9 +82,12 @@ class Fieldset_Component extends Component {
 
 		$this->fieldset_attributes = Attributes::parse( $attributes );
 
-		$this->legend       = $fieldset->get_legend();
-		$this->legend_class = $fieldset->get_style()->legend_class();
-		$this->before       = $fieldset->get_before() ?? '';
-		$this->after        = $fieldset->get_after() ?? '';
+		$this->legend            = $fieldset->get_legend();
+		$this->legend_class      = $fieldset->get_style()->legend_class();
+		$this->before            = $fieldset->get_before() ?? '';
+		$this->after             = $fieldset->get_after() ?? '';
+		$this->pre_description   = $fieldset->get_pre_description();
+		$this->post_description  = $fieldset->get_post_description();
+		$this->description_class = $fieldset->get_style()->description_class();
 	}
 }

--- a/src/Element/Custom_Field.php
+++ b/src/Element/Custom_Field.php
@@ -34,10 +34,11 @@ use PinkCrab\Form_Components\Element\Field;
 use PinkCrab\Form_Components\Element\Field\Attribute\Label;
 use PinkCrab\Form_Components\Element\Field\Attribute\Single_Value;
 use PinkCrab\Form_Components\Element\Field\Attribute\Notification;
+use PinkCrab\Form_Components\Element\Field\Attribute\Description;
 
 class Custom_Field extends Field {
 
-	use Label, Single_Value, Notification;
+	use Label, Single_Value, Notification, Description;
 
 	/**
 	 * The HTML content to render in the field slot.

--- a/src/Element/Field/Attribute/Description.php
+++ b/src/Element/Field/Attribute/Description.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Adds optional pre and post descriptions to a field.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @package PinkCrab\Form_Fields
+ */
+
+namespace PinkCrab\Form_Components\Element\Field\Attribute;
+
+trait Description {
+
+	/**
+	 * Description displayed before the input.
+	 *
+	 * @var string|null
+	 */
+	protected $pre_description = null;
+
+	/**
+	 * Description displayed after the input.
+	 *
+	 * @var string|null
+	 */
+	protected $post_description = null;
+
+	/**
+	 * Sets the pre-description (displayed before the input).
+	 *
+	 * @param string $description
+	 * @return static
+	 */
+	public function pre_description( string $description ): self {
+		$this->pre_description = $description;
+		return $this;
+	}
+
+	/**
+	 * Gets the pre-description.
+	 *
+	 * @return string|null
+	 */
+	public function get_pre_description(): ?string {
+		return $this->pre_description;
+	}
+
+	/**
+	 * Checks if the field has a pre-description.
+	 *
+	 * @return bool
+	 */
+	public function has_pre_description(): bool {
+		return ! is_null( $this->pre_description );
+	}
+
+	/**
+	 * Sets the post-description (displayed after the input).
+	 *
+	 * @param string $description
+	 * @return static
+	 */
+	public function post_description( string $description ): self {
+		$this->post_description = $description;
+		return $this;
+	}
+
+	/**
+	 * Gets the post-description.
+	 *
+	 * @return string|null
+	 */
+	public function get_post_description(): ?string {
+		return $this->post_description;
+	}
+
+	/**
+	 * Checks if the field has a post-description.
+	 *
+	 * @return bool
+	 */
+	public function has_post_description(): bool {
+		return ! is_null( $this->post_description );
+	}
+}

--- a/src/Element/Field/Group/Checkbox_Group.php
+++ b/src/Element/Field/Group/Checkbox_Group.php
@@ -27,11 +27,11 @@ declare( strict_types=1 );
 namespace PinkCrab\Form_Components\Element\Field\Group;
 
 use PinkCrab\Form_Components\Element\Field;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Options, Notification, Disabled};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Options, Notification, Disabled, Description};
 
 class Checkbox_Group extends Field {
 
-	use Label, Options, Notification, Disabled;
+	use Label, Options, Notification, Disabled, Description;
 
 	/**
 	 * The selected values.

--- a/src/Element/Field/Group/Radio_Group.php
+++ b/src/Element/Field/Group/Radio_Group.php
@@ -27,11 +27,11 @@ declare( strict_types=1 );
 namespace PinkCrab\Form_Components\Element\Field\Group;
 
 use PinkCrab\Form_Components\Element\Field;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Options, Notification, Disabled, Required};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Options, Notification, Disabled, Required, Description};
 
 class Radio_Group extends Field {
 
-	use Label, Options, Notification, Disabled, Required;
+	use Label, Options, Notification, Disabled, Required, Description;
 
 	/**
 	 * The selected value.

--- a/src/Element/Field/Input/Abstract_Input.php
+++ b/src/Element/Field/Input/Abstract_Input.php
@@ -34,10 +34,11 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 use PinkCrab\Form_Components\Element\Field_Traits\Form_Style;
 use PinkCrab\Form_Components\Element\Field\Attribute\Notification;
 use PinkCrab\Form_Components\Element\Field\Attribute\Single_Value;
+use PinkCrab\Form_Components\Element\Field\Attribute\Description;
 
 class Abstract_Input extends Field {
 
-	use Label, Single_Value, Form_Style, Notification;
+	use Label, Single_Value, Form_Style, Notification, Description;
 
 	/**
 	 * Set the value of the input

--- a/src/Element/Field/Select.php
+++ b/src/Element/Field/Select.php
@@ -29,11 +29,11 @@ use PinkCrab\Form_Components\Element\Field;
 use PinkCrab\Form_Components\Util\Sanitize;
 use PinkCrab\Form_Components\Element\Field_Traits\Sanitizer;
 use function PinkCrab\FunctionConstructors\Objects\usesTrait;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Single_Value, Notification, Options, Disabled, Required, Multiple, Autocomplete, Size};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Single_Value, Notification, Options, Disabled, Required, Multiple, Autocomplete, Size, Description};
 
 class Select extends Field {
 
-	use Label, Single_Value, Notification, Options, Disabled, Required, Multiple, Autocomplete, Size;
+	use Label, Single_Value, Notification, Options, Disabled, Required, Multiple, Autocomplete, Size, Description;
 
 	/**
 	 * Holds the value of the field (may be array when multiple).

--- a/src/Element/Field/Textarea.php
+++ b/src/Element/Field/Textarea.php
@@ -29,11 +29,11 @@ use PinkCrab\Form_Components\Element\Field;
 use PinkCrab\Form_Components\Util\Sanitize;
 use PinkCrab\Form_Components\Element\Field_Traits\Sanitizer;
 use function PinkCrab\FunctionConstructors\Objects\usesTrait;
-use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Single_Value, Notification, Placeholder, Disabled, Read_Only, Required, Length, Spellcheck, Autocomplete};
+use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Single_Value, Notification, Placeholder, Disabled, Read_Only, Required, Length, Spellcheck, Autocomplete, Description};
 
 class Textarea extends Field {
 
-	use Label, Single_Value, Notification, Placeholder, Disabled, Read_Only, Required, Length, Spellcheck, Autocomplete;
+	use Label, Single_Value, Notification, Placeholder, Disabled, Read_Only, Required, Length, Spellcheck, Autocomplete, Description;
 
 	/**
 	 * The default sanitizer for the textarea.

--- a/src/Element/Fieldset.php
+++ b/src/Element/Fieldset.php
@@ -35,12 +35,13 @@ use PinkCrab\Form_Components\Element\Field_Traits\Form_Style;
 use PinkCrab\Form_Components\Element\Field_Traits\Element_Wrap;
 use PinkCrab\Form_Components\Element\Field_Traits\Wrapper_Attributes;
 use PinkCrab\Form_Components\Element\Field\Attribute\Disabled;
+use PinkCrab\Form_Components\Element\Field\Attribute\Description;
 
 use function PinkCrab\FunctionConstructors\GeneralFunctions\pipe;
 
 class Fieldset implements Element {
 
-	use Wrapper_Attributes, Attributes, Element_Wrap, Fields, Form_Style, Disabled;
+	use Wrapper_Attributes, Attributes, Element_Wrap, Fields, Form_Style, Disabled, Description;
 
 	/**
 	 * The fieldset name.

--- a/src/Style/Default_Style.php
+++ b/src/Style/Default_Style.php
@@ -76,4 +76,9 @@ class Default_Style implements Style {
 	public function legend_class(): string {
 		return 'pc-form__legend';
 	}
+
+	/** @inheritDoc */
+	public function description_class(): string {
+		return 'pc-form__description';
+	}
 }

--- a/src/Style/Style.php
+++ b/src/Style/Style.php
@@ -108,4 +108,11 @@ interface Style {
 	 * @return string
 	 */
 	public function legend_class(): string;
+
+	/**
+	 * Description element class.
+	 *
+	 * @return string
+	 */
+	public function description_class(): string;
 }

--- a/template/component/field/checkbox-group.php
+++ b/template/component/field/checkbox-group.php
@@ -22,6 +22,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<legend><?php echo esc_html( $field->get_label() ); ?></legend>
 	<?php endif; ?>
 
+	<?php if ( $field->has_pre_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_pre_description() ); ?></p>
+	<?php endif; ?>
+
 	<?php foreach ( $field->get_options() as $value => $label ) : ?>
 		<label class="<?php echo esc_attr( sprintf( $field->get_style()->group_option_class(), 'checkbox-group' ) ); ?>">
 			<input
@@ -34,6 +38,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 			<?php echo esc_html( $label ); ?>
 		</label>
 	<?php endforeach; ?>
+
+	<?php if ( $field->has_post_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_post_description() ); ?></p>
+	<?php endif; ?>
 
 	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Notification::class )( $field ) && $field->has_notification() ) : ?>
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>

--- a/template/component/field/custom-field.php
+++ b/template/component/field/custom-field.php
@@ -26,7 +26,15 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Label_Component( $field->get_label(), $field->get_name(), $field->get_style()->label_class() ) ); ?>
 	<?php endif; ?>
 
+	<?php if ( $field->has_pre_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_pre_description() ); ?></p>
+	<?php endif; ?>
+
 	<?php echo $content; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, filtered through kses in component. ?>
+
+	<?php if ( $field->has_post_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_post_description() ); ?></p>
+	<?php endif; ?>
 
 	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Notification::class )( $field ) && $field->has_notification() ) : ?>
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>

--- a/template/component/field/input-text.php
+++ b/template/component/field/input-text.php
@@ -21,6 +21,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Label_Component( $field->get_label(), $field->get_name(), $field->get_style()->label_class() ) ); ?>
 	<?php endif; ?>
 
+	<?php if ( $field->has_pre_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_pre_description() ); ?></p>
+	<?php endif; ?>
+
 	<input
 		type="<?php echo esc_attr( $input_type ); ?>"
 		name="<?php echo esc_attr( $field->get_name() ); ?>"
@@ -30,6 +34,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 
 	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Datalist::class )( $field ) && $field->has_datalist_items() ) : ?>
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Datalist_Component( $field->get_datalist_key(), $field->get_datalist_items() ) ); ?>
+	<?php endif; ?>
+
+	<?php if ( $field->has_post_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_post_description() ); ?></p>
 	<?php endif; ?>
 
 	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Notification::class )( $field ) && $field->has_notification() ) : ?>

--- a/template/component/field/radio-group.php
+++ b/template/component/field/radio-group.php
@@ -22,6 +22,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<legend><?php echo esc_html( $field->get_label() ); ?></legend>
 	<?php endif; ?>
 
+	<?php if ( $field->has_pre_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_pre_description() ); ?></p>
+	<?php endif; ?>
+
 	<?php foreach ( $field->get_options() as $value => $label ) : ?>
 		<label class="<?php echo esc_attr( sprintf( $field->get_style()->group_option_class(), 'radio-group' ) ); ?>">
 			<input
@@ -34,6 +38,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 			<?php echo esc_html( $label ); ?>
 		</label>
 	<?php endforeach; ?>
+
+	<?php if ( $field->has_post_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_post_description() ); ?></p>
+	<?php endif; ?>
 
 	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Notification::class )( $field ) && $field->has_notification() ) : ?>
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>

--- a/template/component/field/select.php
+++ b/template/component/field/select.php
@@ -22,6 +22,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Label_Component( $field->get_label(), $field->get_name(), $field->get_style()->label_class() ) ); ?>
 	<?php endif; ?>
 
+	<?php if ( $field->has_pre_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_pre_description() ); ?></p>
+	<?php endif; ?>
+
 	<select
 		name="<?php echo esc_attr( $field->get_name() ); ?><?php echo $field->is_multiple() ? '[]' : ''; ?>"
 		<?php echo $field_attributes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, parts escaped before composition. ?>
@@ -46,6 +50,10 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 			<?php endforeach; ?>
 		<?php endif; ?>
 	</select>
+
+	<?php if ( $field->has_post_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_post_description() ); ?></p>
+	<?php endif; ?>
 
 	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Notification::class )( $field ) && $field->has_notification() ) : ?>
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>

--- a/template/component/field/textarea.php
+++ b/template/component/field/textarea.php
@@ -22,12 +22,20 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Label_Component( $field->get_label(), $field->get_name(), $field->get_style()->label_class() ) ); ?>
 	<?php endif; ?>
 
+	<?php if ( $field->has_pre_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_pre_description() ); ?></p>
+	<?php endif; ?>
+
 	<textarea
 		name="<?php echo esc_attr( $field->get_name() ); ?>"
 		<?php echo $field_attributes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, parts escaped before composition. ?>
 		<?php echo $field->has_rows() ? 'rows="' . esc_attr( (string) $field->get_rows() ) . '"' : ''; ?>
 		<?php echo $field->has_cols() ? 'cols="' . esc_attr( (string) $field->get_cols() ) . '"' : ''; ?>
 	><?php echo $field->has_value() ? esc_textarea( (string) $field->get_value() ) : ''; ?></textarea>
+
+	<?php if ( $field->has_post_description() ) : ?>
+		<p class="<?php echo esc_attr( $field->get_style()->description_class() ); ?>"><?php echo wp_kses_post( $field->get_post_description() ); ?></p>
+	<?php endif; ?>
 
 	<?php if ( usesTrait( PinkCrab\Form_Components\Element\Field\Attribute\Notification::class )( $field ) && $field->has_notification() ) : ?>
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>

--- a/template/component/form/fieldset.php
+++ b/template/component/form/fieldset.php
@@ -16,9 +16,15 @@
 	<?php if ( $legend ) : ?>
 		<legend<?php echo $legend_class ? ' class="' . esc_attr( $legend_class ) . '"' : ''; ?>><?php echo esc_html( $legend ); ?></legend>
 	<?php endif; ?>
+	<?php if ( $pre_description ) : ?>
+		<p class="<?php echo esc_attr( $description_class ); ?>"><?php echo wp_kses_post( $pre_description ); ?></p>
+	<?php endif; ?>
 	<?php echo wp_kses_post( $before ); ?>
 	<?php foreach ( $components as $component ) : ?>
 		<?php $this->component( $component ); ?>
 	<?php endforeach; ?>
+	<?php if ( $post_description ) : ?>
+		<p class="<?php echo esc_attr( $description_class ); ?>"><?php echo wp_kses_post( $post_description ); ?></p>
+	<?php endif; ?>
 	<?php echo wp_kses_post( $after ); ?>
 </fieldset>

--- a/tests/Unit/Element/Group/Test_Checkbox_Group.php
+++ b/tests/Unit/Element/Group/Test_Checkbox_Group.php
@@ -24,6 +24,7 @@ use PinkCrab\Form_Components\Element\Field\Group\Checkbox_Group;
 class Test_Checkbox_Group extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Group/Test_Radio_Group.php
+++ b/tests/Unit/Element/Group/Test_Radio_Group.php
@@ -24,6 +24,7 @@ use PinkCrab\Form_Components\Element\Field\Group\Radio_Group;
 class Test_Radio_Group extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Button.php
+++ b/tests/Unit/Element/Input/Test_Button.php
@@ -29,6 +29,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Disabled, Read_Only, Requi
 class Test_Button extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Checkbox.php
+++ b/tests/Unit/Element/Input/Test_Checkbox.php
@@ -25,6 +25,7 @@ use PinkCrab\Form_Components\Tests\Fixtures\Mock_Objects\Stringable_Stub;
 class Test_Checkbox extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Color.php
+++ b/tests/Unit/Element/Input/Test_Color.php
@@ -27,6 +27,7 @@ use PinkCrab\Form_Components\Element\Field\Input\Color;
 class Test_Color extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Date.php
+++ b/tests/Unit/Element/Input/Test_Date.php
@@ -26,6 +26,7 @@ use PinkCrab\Form_Components\Element\Field\Input\Date;
 class Test_Date extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_DateTime.php
+++ b/tests/Unit/Element/Input/Test_DateTime.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Range, Autocomplete, Place
 class Test_DateTime extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Email.php
+++ b/tests/Unit/Element/Input/Test_Email.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Single_Value,Multiple, Dat
 class Test_Email extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_File.php
+++ b/tests/Unit/Element/Input/Test_File.php
@@ -27,6 +27,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Single_Value,Multiple, Dis
 class Test_File extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Hidden.php
+++ b/tests/Unit/Element/Input/Test_Hidden.php
@@ -25,6 +25,7 @@ use PinkCrab\Form_Components\Element\Field\Input\Hidden;
 class Test_Hidden extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Month.php
+++ b/tests/Unit/Element/Input/Test_Month.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Range, Autocomplete, Place
 class Test_Month extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Number.php
+++ b/tests/Unit/Element/Input/Test_Number.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Single_Value,Range, Placeh
 class Test_Number extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Password.php
+++ b/tests/Unit/Element/Input/Test_Password.php
@@ -27,6 +27,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Single_Value,Autocomplete,
 class Test_Password extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Radio.php
+++ b/tests/Unit/Element/Input/Test_Radio.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Checked, Disabled};
 class Test_Radio extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Submit.php
+++ b/tests/Unit/Element/Input/Test_Submit.php
@@ -29,6 +29,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Disabled, Read_Only, Requi
 class Test_Submit extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Tel.php
+++ b/tests/Unit/Element/Input/Test_Tel.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Single_Value,Autocomplete,
 class Test_Tel extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Text.php
+++ b/tests/Unit/Element/Input/Test_Text.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Single_Value,Autocomplete,
 class Test_Text extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Time.php
+++ b/tests/Unit/Element/Input/Test_Time.php
@@ -27,6 +27,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Range, Autocomplete, Place
 class Test_Time extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Url.php
+++ b/tests/Unit/Element/Input/Test_Url.php
@@ -28,6 +28,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Single_Value,Autocomplete,
 class Test_Url extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Input/Test_Week.php
+++ b/tests/Unit/Element/Input/Test_Week.php
@@ -27,6 +27,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Range, Autocomplete, Place
 class Test_Week extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Shared_Description_Cases.php
+++ b/tests/Unit/Element/Shared_Description_Cases.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared test cases for the Description trait.
+ *
+ * @see https://github.com/Pink-Crab/Perique-Form-Components/issues/18
+ *
+ * @since 2.2.0
+ * @author GLynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Form_Components\Tests\Unit\Element;
+
+use PinkCrab\Form_Components\Element\Field;
+
+trait Shared_Description_Cases {
+
+	/**
+	 * Abstract method for getting the class under test.
+	 *
+	 * @return class-string<Field>
+	 */
+	abstract public function get_class_under_test(): string;
+
+	/** @testdox [Shared::Description] It should be possible to set and get a pre-description */
+	public function test_pre_description_set_and_get(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$field->pre_description( 'Hint before input' );
+		$this->assertTrue( $field->has_pre_description() );
+		$this->assertSame( 'Hint before input', $field->get_pre_description() );
+	}
+
+	/** @testdox [Shared::Description] It should be possible to set and get a post-description */
+	public function test_post_description_set_and_get(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$field->post_description( 'Help text after input' );
+		$this->assertTrue( $field->has_post_description() );
+		$this->assertSame( 'Help text after input', $field->get_post_description() );
+	}
+
+	/** @testdox [Shared::Description] A field with no pre-description should return null */
+	public function test_no_pre_description_returns_null(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$this->assertFalse( $field->has_pre_description() );
+		$this->assertNull( $field->get_pre_description() );
+	}
+
+	/** @testdox [Shared::Description] A field with no post-description should return null */
+	public function test_no_post_description_returns_null(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$this->assertFalse( $field->has_post_description() );
+		$this->assertNull( $field->get_post_description() );
+	}
+
+	/** @testdox [Shared::Description] It should be possible to set both pre and post descriptions */
+	public function test_both_descriptions(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$field->pre_description( 'Before' );
+		$field->post_description( 'After' );
+
+		$this->assertSame( 'Before', $field->get_pre_description() );
+		$this->assertSame( 'After', $field->get_post_description() );
+	}
+
+	/** @testdox [Shared::Description] Setting pre-description should return self for fluent chaining */
+	public function test_pre_description_fluent(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$this->assertSame( $field, $field->pre_description( 'test' ) );
+	}
+
+	/** @testdox [Shared::Description] Setting post-description should return self for fluent chaining */
+	public function test_post_description_fluent(): void {
+		$class = $this->get_class_under_test();
+		$field = new $class( 'test' );
+
+		$this->assertSame( $field, $field->post_description( 'test' ) );
+	}
+}

--- a/tests/Unit/Element/Test_Custom_Field.php
+++ b/tests/Unit/Element/Test_Custom_Field.php
@@ -28,6 +28,7 @@ use PinkCrab\Perique\Services\View\Component\Component;
 class Test_Custom_Field extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Test_Fieldset.php
+++ b/tests/Unit/Element/Test_Fieldset.php
@@ -274,4 +274,42 @@ class Test_Fieldset extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'foo', $fieldset->get_attribute( 'class' ) );
 		$this->assertStringContainsString( 'bar', $fieldset->get_attribute( 'class' ) );
 	}
+
+	####################################################################
+	######                  DESCRIPTION                            ######
+	####################################################################
+
+	/**
+	 * @testdox It should be possible to set and get a pre-description
+	 * @see https://github.com/Pink-Crab/Perique-Form-Components/issues/18
+	 */
+	public function test_pre_description(): void {
+		$fieldset = new Fieldset( 'test' );
+		$fieldset->pre_description( 'Hint before fields' );
+		$this->assertTrue( $fieldset->has_pre_description() );
+		$this->assertSame( 'Hint before fields', $fieldset->get_pre_description() );
+	}
+
+	/**
+	 * @testdox It should be possible to set and get a post-description
+	 * @see https://github.com/Pink-Crab/Perique-Form-Components/issues/18
+	 */
+	public function test_post_description(): void {
+		$fieldset = new Fieldset( 'test' );
+		$fieldset->post_description( 'Help text after fields' );
+		$this->assertTrue( $fieldset->has_post_description() );
+		$this->assertSame( 'Help text after fields', $fieldset->get_post_description() );
+	}
+
+	/**
+	 * @testdox A fieldset with no descriptions should return null
+	 * @see https://github.com/Pink-Crab/Perique-Form-Components/issues/18
+	 */
+	public function test_no_descriptions_returns_null(): void {
+		$fieldset = new Fieldset( 'test' );
+		$this->assertFalse( $fieldset->has_pre_description() );
+		$this->assertFalse( $fieldset->has_post_description() );
+		$this->assertNull( $fieldset->get_pre_description() );
+		$this->assertNull( $fieldset->get_post_description() );
+	}
 }

--- a/tests/Unit/Element/Test_Select.php
+++ b/tests/Unit/Element/Test_Select.php
@@ -27,6 +27,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Single_Value, Optio
 class Test_Select extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Element/Test_Textarea.php
+++ b/tests/Unit/Element/Test_Textarea.php
@@ -27,6 +27,7 @@ use PinkCrab\Form_Components\Element\Field\Attribute\{Label, Single_Value, Place
 class Test_Textarea extends WP_UnitTestCase {
 
 	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Field_Cases;
+	use \PinkCrab\Form_Components\Tests\Unit\Element\Shared_Description_Cases;
 
 	/** @inheritDoc */
 	public function get_class_under_test(): string {

--- a/tests/Unit/Style/Test_Style_Provider.php
+++ b/tests/Unit/Style/Test_Style_Provider.php
@@ -48,6 +48,7 @@ class Test_Style_Provider extends WP_UnitTestCase {
 			public function group_option_class(): string { return '%s__custom-option'; }
 			public function label_class(): string { return 'custom-label'; }
 			public function legend_class(): string { return 'custom-legend'; }
+			public function description_class(): string { return 'custom-description'; }
 		};
 
 		Style_Provider::set_default_style( get_class( $custom_style ) );

--- a/tests/e2e/views/fields/_custom-style.php
+++ b/tests/e2e/views/fields/_custom-style.php
@@ -38,5 +38,8 @@ if ( ! class_exists( 'E2E_Custom_Style' ) ) {
 		public function legend_class(): string {
 			return 'custom-legend';
 		}
+		public function description_class(): string {
+			return 'custom-description';
+		}
 	}
 }


### PR DESCRIPTION
This pull request updates the documentation for several field types to include new `pre_description` and `post_description` methods, which allow developers to add descriptive text before and after form inputs. The documentation tables are also updated to list these new methods and their corresponding getters and checkers. Additionally, a new script for running end-to-end tests is added to `composer.json`.

**Documentation updates for new description methods:**

* Added `pre_description` and `post_description` method documentation to the following field types, including usage examples:
  - `Checkbox`, `Checkbox_Group`, `Color`, `Custom_Field`, `Date`, `Datetime`, `Email`, `Fieldset`, `File`, `Hidden`, `Month`, `Number`, and `Password` (`docs/fields/checkbox.md` [[1]](diffhunk://#diff-e076e56b172a9935afde9ea83fb07dbcc67408eb2e1affa9f89780b1a3c15990R288-R307) `docs/fields/checkbox-group.md` [[2]](diffhunk://#diff-60c2a7f390d02dadac84527350dbce1844da52fea75ee668c9c432750adc142dR367-R386) `docs/fields/color.md` [[3]](diffhunk://#diff-22badaeb73b93aa217dcabf6d3998741fe695e94a5d1de2babbb5d80d8e64f52R329-R348) `docs/fields/custom-field.md` [[4]](diffhunk://#diff-a712c8e7a72f09869780c7f12749b162e5608788bcba571c3b131680679ea148R152-R171) `docs/fields/date.md` [[5]](diffhunk://#diff-816766a2531ea49eb32c88648719a61983dfc174bfe3e40de45389311d76d789R454-R473) `docs/fields/datetime.md` [[6]](diffhunk://#diff-09a527db5aa96abb18ed5443202ffd3f0549de78749d89d4a66356af2899a5caR552-R571) `docs/fields/email.md` [[7]](diffhunk://#diff-3b6a6a53425c544486ec3003b15998e68d87ab7a0f71e6e93e97f0d8fcd9ce95R479-R498) `docs/fields/fieldset.md` [[8]](diffhunk://#diff-a2f075a4e789ba86d954f5ee1a6b055f6a71604418bfaf1f47063e0a120c48c6R258-R283) `docs/fields/file.md` [[9]](diffhunk://#diff-827d0eaa92c4bc42bb5e5c0a45b8002aebfe0ea5bf0145e41d3bfbfbd365c7e6R312-R331) `docs/fields/hidden.md` [[10]](diffhunk://#diff-720f1d4855dc49d34ecb295e78a681b140c5f26ce4c50a5619f7b098effe8c98R286-R303) `docs/fields/month.md` [[11]](diffhunk://#diff-185bec0896c5642e718115712fb33cbcc07d80c6a5c53ede642fc146f134ff90R469-R488) `docs/fields/number.md` [[12]](diffhunk://#diff-b0b84a96f3f8a32676851df8efd0ad1416e8ae85451113a7447d90bdabef2731R460-R479) `docs/fields/password.md` [[13]](diffhunk://#diff-b2d37ecbf4b09df36d49af224f80cb15ed5f331908fadd2f58313e5599f8410aR398-R417).

* Updated documentation tables for each field type to include `pre_description`, `post_description`, and their related getter/checker methods:
  - All affected field documentation files now list `pre_description()`, `post_description()`, `get_pre_description()`, `get_post_description()`, `has_pre_description()`, and `has_post_description()` in their method tables. [[1]](diffhunk://#diff-e076e56b172a9935afde9ea83fb07dbcc67408eb2e1affa9f89780b1a3c15990R605) [[2]](diffhunk://#diff-60c2a7f390d02dadac84527350dbce1844da52fea75ee668c9c432750adc142dR616) [[3]](diffhunk://#diff-22badaeb73b93aa217dcabf6d3998741fe695e94a5d1de2babbb5d80d8e64f52R650) [[4]](diffhunk://#diff-a712c8e7a72f09869780c7f12749b162e5608788bcba571c3b131680679ea148R217) [[5]](diffhunk://#diff-816766a2531ea49eb32c88648719a61983dfc174bfe3e40de45389311d76d789R773) [[6]](diffhunk://#diff-09a527db5aa96abb18ed5443202ffd3f0549de78749d89d4a66356af2899a5caR871) [[7]](diffhunk://#diff-3b6a6a53425c544486ec3003b15998e68d87ab7a0f71e6e93e97f0d8fcd9ce95R804) [[8]](diffhunk://#diff-a2f075a4e789ba86d954f5ee1a6b055f6a71604418bfaf1f47063e0a120c48c6R679) [[9]](diffhunk://#diff-827d0eaa92c4bc42bb5e5c0a45b8002aebfe0ea5bf0145e41d3bfbfbd365c7e6R620) [[10]](diffhunk://#diff-720f1d4855dc49d34ecb295e78a681b140c5f26ce4c50a5619f7b098effe8c98R551) [[11]](diffhunk://#diff-185bec0896c5642e718115712fb33cbcc07d80c6a5c53ede642fc146f134ff90R789) [[12]](diffhunk://#diff-b0b84a96f3f8a32676851df8efd0ad1416e8ae85451113a7447d90bdabef2731R779) [[13]](diffhunk://#diff-b2d37ecbf4b09df36d49af224f80cb15ed5f331908fadd2f58313e5599f8410aR749)

**Build and test improvements:**

* Added a new `e2e` script to `composer.json` for running end-to-end tests with a specified base URL.
* 
closes #18 