### PR TITLE
fix: guard before/after adornment echoes against null in field templa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ $this->component( Make::form( 'enquiry', fn( $f ) => $f
 
 ## Change Log
 
+* 2.1.5 - Field templates no longer pass a `null` `before_field` / `after_field` to `wp_kses_post()` when `before()` / `after()` weren't called — the strict empty-string check introduced in 2.1.4 didn't account for the unset (null) case, which triggered a `preg_replace(): Passing null` deprecation on PHP 8.1+. Fixed by checking for both null and empty string. (Issue #25)
 * 2.1.4 - Field names containing PHP-style brackets (e.g. `wm_loc_coordinates[0][latlong]`) and case-sensitive characters are now preserved verbatim rather than being mangled by `sanitize_title()`. `before()` / `after()` adornments now render whether `show_wrapper(false)` or `show_wrapper(true)` is set — they were previously dropped when the wrapper was off. (Issue #23)
 *2.1.3 - Adds description pre and post fields within the field wrapper.
 * 2.1.2 - Fixed label/input accessibility, wrapper class duplication and unnecessary `list` attribute rendering.

--- a/template/component/field/button.php
+++ b/template/component/field/button.php
@@ -18,7 +18,7 @@
 <?php if ( $show_wrapper ) : ?>
 	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes ) ); ?>
 <?php endif; ?>
-	<?php if ( '' !== $before_field ) : ?>
+	<?php if ( null !== $before_field && '' !== $before_field ) : ?>
 		<?php echo wp_kses_post( $before_field ); ?>
 	<?php endif; ?>
 	<button
@@ -26,7 +26,7 @@
 		name="<?php echo esc_attr( $field->get_name() ); ?>"
 		<?php echo $field_attributes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, parts escaped before composition. ?>
 	><?php echo wp_kses_post( $text ); ?></button>
-	<?php if ( '' !== $after_field ) : ?>
+	<?php if ( null !== $after_field && '' !== $after_field ) : ?>
 		<?php echo wp_kses_post( $after_field ); ?>
 	<?php endif; ?>
 <?php if ( $show_wrapper ) : ?>

--- a/template/component/field/checkbox-group.php
+++ b/template/component/field/checkbox-group.php
@@ -18,7 +18,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 <?php if ( $show_wrapper ) : ?>
 	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes ) ); ?>
 <?php endif; ?>
-	<?php if ( '' !== $before_field ) : ?>
+	<?php if ( null !== $before_field && '' !== $before_field ) : ?>
 		<?php echo wp_kses_post( $before_field ); ?>
 	<?php endif; ?>
 	<?php if ( $field->has_label() ) : ?>
@@ -50,7 +50,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>
 	<?php endif; ?>
 
-	<?php if ( '' !== $after_field ) : ?>
+	<?php if ( null !== $after_field && '' !== $after_field ) : ?>
 		<?php echo wp_kses_post( $after_field ); ?>
 	<?php endif; ?>
 

--- a/template/component/field/custom-field.php
+++ b/template/component/field/custom-field.php
@@ -22,7 +22,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 <?php if ( $show_wrapper ) : ?>
 	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes ) ); ?>
 <?php endif; ?>
-	<?php if ( '' !== $before_field ) : ?>
+	<?php if ( null !== $before_field && '' !== $before_field ) : ?>
 		<?php echo wp_kses_post( $before_field ); ?>
 	<?php endif; ?>
 	<?php if ( $field->has_label() ) : ?>
@@ -43,7 +43,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>
 	<?php endif; ?>
 
-	<?php if ( '' !== $after_field ) : ?>
+	<?php if ( null !== $after_field && '' !== $after_field ) : ?>
 		<?php echo wp_kses_post( $after_field ); ?>
 	<?php endif; ?>
 

--- a/template/component/field/input-text.php
+++ b/template/component/field/input-text.php
@@ -19,7 +19,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 <?php if ( $show_wrapper ) : ?>
 	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes ) ); ?>
 <?php endif; ?>
-	<?php if ( '' !== $before_field ) : ?>
+	<?php if ( null !== $before_field && '' !== $before_field ) : ?>
 		<?php echo wp_kses_post( $before_field ); ?>
 	<?php endif; ?>
 	<?php if ( $field->has_label() ) : ?>
@@ -49,7 +49,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>
 	<?php endif; ?>
 
-	<?php if ( '' !== $after_field ) : ?>
+	<?php if ( null !== $after_field && '' !== $after_field ) : ?>
 		<?php echo wp_kses_post( $after_field ); ?>
 	<?php endif; ?>
 

--- a/template/component/field/radio-group.php
+++ b/template/component/field/radio-group.php
@@ -18,7 +18,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 <?php if ( $show_wrapper ) : ?>
 	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes ) ); ?>
 <?php endif; ?>
-	<?php if ( '' !== $before_field ) : ?>
+	<?php if ( null !== $before_field && '' !== $before_field ) : ?>
 		<?php echo wp_kses_post( $before_field ); ?>
 	<?php endif; ?>
 	<?php if ( $field->has_label() ) : ?>
@@ -50,7 +50,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>
 	<?php endif; ?>
 
-	<?php if ( '' !== $after_field ) : ?>
+	<?php if ( null !== $after_field && '' !== $after_field ) : ?>
 		<?php echo wp_kses_post( $after_field ); ?>
 	<?php endif; ?>
 

--- a/template/component/field/select.php
+++ b/template/component/field/select.php
@@ -18,7 +18,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 <?php if ( $show_wrapper ) : ?>
 	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes ) ); ?>
 <?php endif; ?>
-	<?php if ( '' !== $before_field ) : ?>
+	<?php if ( null !== $before_field && '' !== $before_field ) : ?>
 		<?php echo wp_kses_post( $before_field ); ?>
 	<?php endif; ?>
 	<?php if ( $field->has_label() ) : ?>
@@ -62,7 +62,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>
 	<?php endif; ?>
 
-	<?php if ( '' !== $after_field ) : ?>
+	<?php if ( null !== $after_field && '' !== $after_field ) : ?>
 		<?php echo wp_kses_post( $after_field ); ?>
 	<?php endif; ?>
 

--- a/template/component/field/textarea.php
+++ b/template/component/field/textarea.php
@@ -18,7 +18,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 <?php if ( $show_wrapper ) : ?>
 	<?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $wrapper_attributes ) ); ?>
 <?php endif; ?>
-	<?php if ( '' !== $before_field ) : ?>
+	<?php if ( null !== $before_field && '' !== $before_field ) : ?>
 		<?php echo wp_kses_post( $before_field ); ?>
 	<?php endif; ?>
 	<?php if ( $field->has_label() ) : ?>
@@ -44,7 +44,7 @@ use function PinkCrab\FunctionConstructors\Objects\usesTrait;
 		<?php $this->component( new PinkCrab\Form_Components\Component\Field\Notification_Component( $field ) ); ?>
 	<?php endif; ?>
 
-	<?php if ( '' !== $after_field ) : ?>
+	<?php if ( null !== $after_field && '' !== $after_field ) : ?>
 		<?php echo wp_kses_post( $after_field ); ?>
 	<?php endif; ?>
 

--- a/template/component/partial/group.php
+++ b/template/component/partial/group.php
@@ -13,7 +13,7 @@
 
 ?>
 <?php $this->component( new PinkCrab\Form_Components\Component\Partial\Field_Wrapper_Start( $attributes ) ); ?>
-		<?php if ( '' !== $before ) : ?>
+		<?php if ( null !== $before && '' !== $before ) : ?>
 			<?php echo wp_kses_post( $before ); ?>
 		<?php endif; ?>
 		<?php
@@ -22,7 +22,7 @@
 			$this->component( $component );
 		}
 		?>
-		<?php if ( '' !== $after ) : ?>
+		<?php if ( null !== $after && '' !== $after ) : ?>
 			<?php echo wp_kses_post( $after ); ?>
 		<?php endif; ?>
 <?php

--- a/tests/Application/Test_Field_Rendering_Adornments.php
+++ b/tests/Application/Test_Field_Rendering_Adornments.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Application-level regression tests for issue #25.
+ *
+ * Renders fields through the real Component_Compiler + PHP_Engine
+ * pipeline and asserts no PHP deprecation/notice fires when before()
+ * / after() are unset (i.e. the field's get_before() / get_after()
+ * return null and the template must NOT pass that null to wp_kses_post()).
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @package PinkCrab\Form_Components
+ */
+
+namespace PinkCrab\Form_Components\Tests\Application;
+
+use WP_UnitTestCase;
+use PinkCrab\Form_Components\Element\Field\Input\Text;
+use PinkCrab\Form_Components\Element\Field\Group\Checkbox_Group;
+use PinkCrab\Form_Components\Element\Field\Group\Radio_Group;
+use PinkCrab\Form_Components\Element\Field\Select;
+use PinkCrab\Form_Components\Element\Field\Textarea;
+use PinkCrab\Form_Components\Element\Custom_Field;
+use PinkCrab\Form_Components\Element\Button;
+use PinkCrab\Form_Components\Component\Field\Input_Component;
+use PinkCrab\Form_Components\Component\Field\Checkbox_Group_Component;
+use PinkCrab\Form_Components\Component\Field\Radio_Group_Component;
+use PinkCrab\Form_Components\Component\Field\Select_Component;
+use PinkCrab\Form_Components\Component\Field\Textarea_Component;
+use PinkCrab\Form_Components\Component\Field\Custom_Field_Component;
+use PinkCrab\Form_Components\Component\Field\Button_Component;
+
+class Test_Field_Rendering_Adornments extends WP_UnitTestCase {
+
+	use Perique_App_Helper;
+
+	public function setUp(): void {
+		parent::setUp();
+		self::unset_app_instance();
+	}
+
+	/**
+	 * Sets up a strict deprecation handler around the closure and asserts
+	 * no E_DEPRECATED / E_USER_DEPRECATED fires. Captures the rendered HTML
+	 * so a stale "Deprecated" string in the output also fails the test.
+	 *
+	 * @param callable(): \PinkCrab\Perique\Services\View\Component\Component $build_component
+	 * @return void
+	 */
+	private function assert_no_deprecation_when_rendering( callable $build_component ): void {
+		$app       = $this->pre_populated_app_provider();
+		$component = $build_component();
+
+		set_error_handler(
+			function ( $errno, $errstr ) {
+				if ( E_DEPRECATED === $errno || E_USER_DEPRECATED === $errno ) {
+					throw new \ErrorException( "Unexpected deprecation while rendering: {$errstr}", 0, $errno );
+				}
+				return false;
+			}
+		);
+
+		try {
+			$output = $app::view()->component( $component, false );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertIsString( $output );
+		$this->assertStringNotContainsString( 'Deprecated', (string) $output );
+	}
+
+	/** @testdox Issue #25: Text input with show_wrapper(false) and no before()/after() renders without a wp_kses_post(null) deprecation. */
+	public function test_text_input_no_wrapper_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Input_Component( Text::make( 'username' )->show_wrapper( false ) )
+		);
+	}
+
+	/** @testdox Issue #25: Text input WITH wrapper but no before()/after() also renders without deprecation. */
+	public function test_text_input_with_wrapper_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Input_Component( Text::make( 'username' ) )
+		);
+	}
+
+	/** @testdox Issue #25: Textarea with no before()/after() renders without deprecation. */
+	public function test_textarea_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Textarea_Component( Textarea::make( 'comments' )->show_wrapper( false ) )
+		);
+	}
+
+	/** @testdox Issue #25: Select with no before()/after() renders without deprecation. */
+	public function test_select_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Select_Component( Select::make( 'choice' )->options( array( 'a' => 'A' ) )->show_wrapper( false ) )
+		);
+	}
+
+	/** @testdox Issue #25: Checkbox group with no before()/after() renders without deprecation. */
+	public function test_checkbox_group_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Checkbox_Group_Component(
+				Checkbox_Group::make( 'tags' )->options( array( 'a' => 'A' ) )->show_wrapper( false )
+			)
+		);
+	}
+
+	/** @testdox Issue #25: Radio group with no before()/after() renders without deprecation. */
+	public function test_radio_group_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Radio_Group_Component(
+				Radio_Group::make( 'priority' )->options( array( 'low' => 'Low' ) )->show_wrapper( false )
+			)
+		);
+	}
+
+	/** @testdox Issue #25: Custom_Field with no before()/after() renders without deprecation. */
+	public function test_custom_field_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Custom_Field_Component( Custom_Field::make( 'cf' )->content( '<p>x</p>' )->show_wrapper( false ) )
+		);
+	}
+
+	/** @testdox Issue #25: Button with no before()/after() renders without deprecation. */
+	public function test_button_no_adornments(): void {
+		$this->assert_no_deprecation_when_rendering(
+			fn() => new Button_Component( Button::make( 'submit' )->text( 'Go' ) )
+		);
+	}
+
+	/** @testdox Issue #25: Adornments still render correctly when before() / after() ARE set (regression check on the fix). */
+	public function test_adornments_render_when_set(): void {
+		$app = $this->pre_populated_app_provider();
+		$field = Text::make( 'username' )
+			->show_wrapper( false )
+			->before( '<span class="ai-marker-before">BEFORE</span>' )
+			->after( '<span class="ai-marker-after">AFTER</span>' );
+
+		$output = $app::view()->component( new Input_Component( $field ), false );
+
+		$this->assertStringContainsString( 'ai-marker-before', (string) $output );
+		$this->assertStringContainsString( 'ai-marker-after', (string) $output );
+	}
+}


### PR DESCRIPTION
…tes (issue #25)

The 2.1.4 hotfix introduced an '' !== $before_field / '' !== $after_field check in every field template, but Field::get_before() / get_after() return null until before()/after() are called — so the guard let null through and wp_kses_post( null ) triggered a preg_replace deprecation on PHP 8.1+.

Switched all 8 templates (input-text, button, select, textarea, checkbox-group, radio-group, custom-field, and the group partial) to an explicit `null !== $X && '' !== $X` check. ! empty() was considered but rejected — it would silently swallow the legitimate '0' string.

Adds tests/Application/Test_Field_Rendering_Adornments.php — boots a real App, renders one component per field type with no before()/after() set, and asserts no E_DEPRECATED fires. The positive regression check verifies adornments still render when before()/after() ARE set.

composer all post-fix: 2014 tests / 3194 assertions / phpstan clean / phpcs clean.