### PR TITLE
chore(docs): normalise code-block indentation from tabs to 4 spaces

### DIFF
--- a/docs/fields/button.md
+++ b/docs/fields/button.md
@@ -12,10 +12,10 @@ Renders a `<button>` element. Unlike form fields, Button extends `Element` direc
 
 ```php
 $this->component( new Button_Component(
-		Button::make( 'btn' )
-			->type( 'button' )
-			->text( 'Click Me' )
-	) )
+        Button::make( 'btn' )
+            ->type( 'button' )
+            ->text( 'Click Me' )
+    ) )
 ```
 
 ![Basic](screenshots/button/basic.png)
@@ -53,8 +53,8 @@ Sets the button type. Common values: `button` (default), `submit`, `reset`.
 
 ```php
 Button::make( 'submit_btn' )
-			->type( 'submit' )
-			->text( 'Submit Form' )
+            ->type( 'submit' )
+            ->text( 'Submit Form' )
 ```
 
 ![submit](screenshots/button/submit.png)
@@ -71,8 +71,8 @@ Button::make( 'submit_btn' )
 
 ```php
 Button::make( 'reset_btn' )
-			->type( 'reset' )
-			->text( 'Reset Form' )
+            ->type( 'reset' )
+            ->text( 'Reset Form' )
 ```
 
 ![reset](screenshots/button/reset.png)
@@ -114,9 +114,9 @@ Disables the button. It is visible but cannot be clicked.
 
 ```php
 Button::make( 'disabled_btn' )
-			->type( 'button' )
-			->text( 'Disabled' )
-			->disabled( true )
+            ->type( 'button' )
+            ->text( 'Disabled' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/button/disabled.png)
@@ -137,10 +137,10 @@ HTML content before or after the button; renders whether or not the wrapper is s
 
 ```php
 Button::make( 'wrapped_btn' )
-			->type( 'button' )
-			->text( 'Wrapped Button' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Action:</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Click to proceed</span>' )
+            ->type( 'button' )
+            ->text( 'Wrapped Button' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Action:</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Click to proceed</span>' )
 ```
 
 ![before/after](screenshots/button/before-after.png)
@@ -207,10 +207,10 @@ Adds a `data-*` attribute to the button element.
 
 ```php
 Button::make( 'action_btn' )
-			->type( 'button' )
-			->text( 'Save Draft' )
-			->data( 'action', 'save-draft' )
-			->data( 'target', 'form-1' )
+            ->type( 'button' )
+            ->text( 'Save Draft' )
+            ->data( 'action', 'save-draft' )
+            ->data( 'target', 'form-1' )
 ```
 
 ![data-attrs](screenshots/button/data-attrs.png)
@@ -253,9 +253,9 @@ Adds a CSS class to the button element.
 
 ```php
 Button::make( 'styled_btn' )
-			->type( 'button' )
-			->text( 'Custom Class' )
-			->add_class( 'my-button-class' )
+            ->type( 'button' )
+            ->text( 'Custom Class' )
+            ->add_class( 'my-button-class' )
 ```
 
 ![custom-class](screenshots/button/custom-class.png)

--- a/docs/fields/checkbox-group.md
+++ b/docs/fields/checkbox-group.md
@@ -11,14 +11,14 @@ Renders a group of `<input type="checkbox">` elements from an options array, all
 
 ```php
 $this->component( new Checkbox_Group_Component(
-		Checkbox_Group::make( 'colours' )
-			->label( 'Favourite Colours' )
-			->options( array(
-				'red'   => 'Red',
-				'green' => 'Green',
-				'blue'  => 'Blue',
-			) )
-	) )
+        Checkbox_Group::make( 'colours' )
+            ->label( 'Favourite Colours' )
+            ->options( array(
+                'red'   => 'Red',
+                'green' => 'Green',
+                'blue'  => 'Blue',
+            ) )
+    ) )
 ```
 
 ![Basic](screenshots/checkbox-group/basic.png)
@@ -125,14 +125,14 @@ Sets which checkboxes are checked by passing an array of values.
 
 ```php
 Checkbox_Group::make( 'languages' )
-			->label( 'Languages' )
-			->options( array(
-				'php'  => 'PHP',
-				'js'   => 'JavaScript',
-				'go'   => 'Go',
-				'rust' => 'Rust',
-			) )
-			->selected( array( 'php', 'js' ) )
+            ->label( 'Languages' )
+            ->options( array(
+                'php'  => 'PHP',
+                'js'   => 'JavaScript',
+                'go'   => 'Go',
+                'rust' => 'Rust',
+            ) )
+            ->selected( array( 'php', 'js' ) )
 ```
 
 ![selected](screenshots/checkbox-group/selected.png)
@@ -211,14 +211,14 @@ Disables the entire checkbox group. Each individual checkbox receives the `disab
 
 ```php
 Checkbox_Group::make( 'locked_choices' )
-			->label( 'Locked Choices' )
-			->options( array(
-				'a' => 'Option A',
-				'b' => 'Option B',
-				'c' => 'Option C',
-			) )
-			->selected( array( 'a', 'c' ) )
-			->disabled( true )
+            ->label( 'Locked Choices' )
+            ->options( array(
+                'a' => 'Option A',
+                'b' => 'Option B',
+                'c' => 'Option C',
+            ) )
+            ->selected( array( 'a', 'c' ) )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/checkbox-group/disabled.png)
@@ -245,13 +245,13 @@ Displays an error message below the group.
 
 ```php
 Checkbox_Group::make( 'features' )
-			->label( 'Features' )
-			->options( array(
-				'sso'  => 'Single Sign-On',
-				'2fa'  => 'Two Factor Auth',
-				'api'  => 'API Access',
-			) )
-			->info_notification( 'Select at least one feature.' )
+            ->label( 'Features' )
+            ->options( array(
+                'sso'  => 'Single Sign-On',
+                '2fa'  => 'Two Factor Auth',
+                'api'  => 'API Access',
+            ) )
+            ->info_notification( 'Select at least one feature.' )
 ```
 
 ![notification](screenshots/checkbox-group/notification.png)
@@ -390,14 +390,14 @@ HTML content before or after the checkbox group; renders whether or not the wrap
 
 ```php
 Checkbox_Group::make( 'topics' )
-			->label( 'Topics' )
-			->options( array(
-				'tech'    => 'Technology',
-				'science' => 'Science',
-				'art'     => 'Art',
-			) )
-			->before( '<span style="color:#6b7280;font-size:13px;">Choose your interests:</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">You can change these later.</span>' )
+            ->label( 'Topics' )
+            ->options( array(
+                'tech'    => 'Technology',
+                'science' => 'Science',
+                'art'     => 'Art',
+            ) )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Choose your interests:</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">You can change these later.</span>' )
 ```
 
 ![before/after](screenshots/checkbox-group/before-after.png)

--- a/docs/fields/checkbox.md
+++ b/docs/fields/checkbox.md
@@ -11,9 +11,9 @@ Renders `<input type="checkbox">`. A single toggle input that can be checked or 
 
 ```php
 $this->component( new Input_Component(
-		Checkbox::make( 'agree' )
-			->label( 'I agree to the terms' )
-	) )
+        Checkbox::make( 'agree' )
+            ->label( 'I agree to the terms' )
+    ) )
 ```
 
 ![Basic](screenshots/checkbox/unchecked.png)
@@ -73,9 +73,9 @@ Sets the value submitted when the checkbox is checked. Non-string values are cas
 
 ```php
 Checkbox::make( 'opt_in' )
-			->label( 'Opt in to marketing' )
-			->value( 'yes' )
-			->checked( true )
+            ->label( 'Opt in to marketing' )
+            ->value( 'yes' )
+            ->checked( true )
 ```
 
 ![value](screenshots/checkbox/value.png)
@@ -122,8 +122,8 @@ Sets whether the checkbox is in a checked state.
 
 ```php
 Checkbox::make( 'newsletter' )
-			->label( 'Subscribe to newsletter' )
-			->checked( true )
+            ->label( 'Subscribe to newsletter' )
+            ->checked( true )
 ```
 
 ![checked](screenshots/checkbox/checked.png)
@@ -169,9 +169,9 @@ Disables the checkbox. It is visible but cannot be toggled or submitted.
 
 ```php
 Checkbox::make( 'mandatory' )
-			->label( 'Mandatory option' )
-			->checked( true )
-			->disabled( true )
+            ->label( 'Mandatory option' )
+            ->checked( true )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/checkbox/disabled.png)
@@ -193,8 +193,8 @@ Displays an error message below the field.
 
 ```php
 Checkbox::make( 'confirm' )
-			->label( 'Confirm your choice' )
-			->warning_notification( 'Please confirm to continue.' )
+            ->label( 'Confirm your choice' )
+            ->warning_notification( 'Please confirm to continue.' )
 ```
 
 ![error_notification](screenshots/checkbox/notification.png)

--- a/docs/fields/color.md
+++ b/docs/fields/color.md
@@ -11,9 +11,9 @@ Renders `<input type="color">` as a colour picker swatch. Default sanitizer: `Sa
 
 ```php
 $this->component( new Input_Component(
-		Color::make( 'brand_color' )
-			->label( 'Brand Colour' )
-	) )
+        Color::make( 'brand_color' )
+            ->label( 'Brand Colour' )
+    ) )
 ```
 
 ![Basic](screenshots/color/basic.png)
@@ -73,8 +73,8 @@ Sets the current colour value. Runs through `sanitize_hex_color()` by default.
 
 ```php
 Color::make( 'theme_color' )
-			->label( 'Theme Colour' )
-			->set_existing( '#3b82f6' )
+            ->label( 'Theme Colour' )
+            ->set_existing( '#3b82f6' )
 ```
 
 ![set_existing](screenshots/color/value.png)
@@ -120,9 +120,9 @@ Disables the input. The colour swatch is visible but cannot be changed.
 
 ```php
 Color::make( 'locked_color' )
-			->label( 'Locked Colour' )
-			->set_existing( '#dc2626' )
-			->disabled( true )
+            ->label( 'Locked Colour' )
+            ->set_existing( '#dc2626' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/color/disabled.png)
@@ -307,9 +307,9 @@ Displays an info message below the field.
 
 ```php
 Color::make( 'info_color' )
-			->label( 'Accent Colour' )
-			->set_existing( '#3b82f6' )
-			->info_notification( 'Choose your brand accent colour.' )
+            ->label( 'Accent Colour' )
+            ->set_existing( '#3b82f6' )
+            ->info_notification( 'Choose your brand accent colour.' )
 ```
 
 ![info_notification](screenshots/color/notification.png)
@@ -352,10 +352,10 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Color::make( 'wrapped_color' )
-			->label( 'Background' )
-			->set_existing( '#f3f4f6' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Pick a background colour</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Used across all pages</span>' )
+            ->label( 'Background' )
+            ->set_existing( '#f3f4f6' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Pick a background colour</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Used across all pages</span>' )
 ```
 
 ![before/after](screenshots/color/before-after.png)

--- a/docs/fields/date.md
+++ b/docs/fields/date.md
@@ -11,9 +11,9 @@ Renders `<input type="date">` with a browser-native date picker. Values are form
 
 ```php
 $this->component( new Input_Component(
-		Date::make( 'birthday' )
-			->label( 'Date of Birth' )
-	) )
+        Date::make( 'birthday' )
+            ->label( 'Date of Birth' )
+    ) )
 ```
 
 ![Basic](screenshots/date/basic.png)
@@ -75,8 +75,8 @@ Sets the current value. Runs through a date format sanitizer (`Y-m-d`) by defaul
 
 ```php
 Date::make( 'event_date' )
-			->label( 'Event Date' )
-			->set_existing( '2026-06-15' )
+            ->label( 'Event Date' )
+            ->set_existing( '2026-06-15' )
 ```
 
 ![set_existing](screenshots/date/value.png)
@@ -477,9 +477,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Date::make( 'wrapped_date' )
-			->label( 'Event Date' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Select your preferred date</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Format: YYYY-MM-DD</span>' )
+            ->label( 'Event Date' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Select your preferred date</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Format: YYYY-MM-DD</span>' )
 ```
 
 ![before/after](screenshots/date/before-after.png)

--- a/docs/fields/datetime.md
+++ b/docs/fields/datetime.md
@@ -11,9 +11,9 @@ Renders `<input type="datetime-local">` with a browser-native date and time pick
 
 ```php
 $this->component( new Input_Component(
-		Datetime::make( 'event' )
-			->label( 'Event Date & Time' )
-	) )
+        Datetime::make( 'event' )
+            ->label( 'Event Date & Time' )
+    ) )
 ```
 
 ![Basic](screenshots/datetime/basic.png)
@@ -75,8 +75,8 @@ Sets the current value. Runs through a datetime format sanitizer (`Y-m-d\TH:i:s`
 
 ```php
 Datetime::make( 'scheduled' )
-			->label( 'Scheduled For' )
-			->set_existing( '2026-06-15T14:30' )
+            ->label( 'Scheduled For' )
+            ->set_existing( '2026-06-15T14:30' )
 ```
 
 ![set_existing](screenshots/datetime/value.png)
@@ -314,8 +314,8 @@ Marks the field as required. The label displays a `*` indicator via CSS.
 
 ```php
 Datetime::make( 'required_dt' )
-			->label( 'Deadline' )
-			->required( true )
+            ->label( 'Deadline' )
+            ->required( true )
 ```
 
 ![required](screenshots/datetime/required.png)
@@ -575,9 +575,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Datetime::make( 'wrapped_dt' )
-			->label( 'Event' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Select date and time</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">All times in UTC</span>' )
+            ->label( 'Event' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Select date and time</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">All times in UTC</span>' )
 ```
 
 ![before/after](screenshots/datetime/before-after.png)

--- a/docs/fields/email.md
+++ b/docs/fields/email.md
@@ -11,10 +11,10 @@ Renders `<input type="email">`. The browser provides built-in email format valid
 
 ```php
 $this->component( new Input_Component(
-		Email::make( 'email' )
-			->label( 'Email Address' )
-			->placeholder( 'you@example.com' )
-	) )
+        Email::make( 'email' )
+            ->label( 'Email Address' )
+            ->placeholder( 'you@example.com' )
+    ) )
 ```
 
 ![Basic](screenshots/email/basic.png)
@@ -383,9 +383,9 @@ Displays an error message below the field.
 
 ```php
 Email::make( 'invalid_email' )
-			->label( 'Email' )
-			->set_existing( 'not-an-email' )
-			->error_notification( 'Please enter a valid email address.' )
+            ->label( 'Email' )
+            ->set_existing( 'not-an-email' )
+            ->error_notification( 'Please enter a valid email address.' )
 ```
 
 ![error_notification](screenshots/email/notification.png)
@@ -502,9 +502,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Email::make( 'wrapped_email' )
-			->label( 'Email' )
-			->before( '<span style="color:#6b7280;font-size:13px;">We will never share your email</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Used for account recovery</span>' )
+            ->label( 'Email' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">We will never share your email</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Used for account recovery</span>' )
 ```
 
 ![before/after](screenshots/email/before-after.png)

--- a/docs/fields/fieldset.md
+++ b/docs/fields/fieldset.md
@@ -12,14 +12,14 @@ Renders a `<fieldset>` element with an optional `<legend>`, wrapping child field
 
 ```php
 $this->component( new Fieldset_Component(
-		Fieldset::make( 'personal' )
-			->legend( 'Personal Information' )
-			->fields(
-				Text::make( 'first_name' )->label( 'First Name' )->required( true ),
-				Text::make( 'last_name' )->label( 'Last Name' )->required( true ),
-				Email::make( 'contact_email' )->label( 'Email' )
-			)
-	) )
+        Fieldset::make( 'personal' )
+            ->legend( 'Personal Information' )
+            ->fields(
+                Text::make( 'first_name' )->label( 'First Name' )->required( true ),
+                Text::make( 'last_name' )->label( 'Last Name' )->required( true ),
+                Email::make( 'contact_email' )->label( 'Email' )
+            )
+    ) )
 ```
 
 ![Basic](screenshots/fieldset/basic.png)
@@ -108,11 +108,11 @@ When no legend is set, the fieldset renders without a `<legend>` tag.
 
 ```php
 Fieldset::make( 'address' )
-			->fields(
-				Text::make( 'street' )->label( 'Street' ),
-				Text::make( 'city' )->label( 'City' ),
-				Text::make( 'postcode' )->label( 'Postcode' )
-			)
+            ->fields(
+                Text::make( 'street' )->label( 'Street' ),
+                Text::make( 'city' )->label( 'City' ),
+                Text::make( 'postcode' )->label( 'Postcode' )
+            )
 ```
 
 ![no-legend](screenshots/fieldset/no-legend.png)
@@ -227,12 +227,12 @@ Disables the entire fieldset, which disables all child form elements.
 
 ```php
 Fieldset::make( 'disabled_section' )
-			->legend( 'Disabled Section' )
-			->disabled( true )
-			->fields(
-				Text::make( 'disabled_name' )->label( 'Name' ),
-				Tel::make( 'disabled_phone' )->label( 'Phone' )
-			)
+            ->legend( 'Disabled Section' )
+            ->disabled( true )
+            ->fields(
+                Text::make( 'disabled_name' )->label( 'Name' ),
+                Tel::make( 'disabled_phone' )->label( 'Phone' )
+            )
 ```
 
 ![disabled](screenshots/fieldset/disabled.png)
@@ -287,13 +287,13 @@ HTML content before or after the fieldset's child elements, rendered inside the 
 
 ```php
 Fieldset::make( 'wrapped_fs' )
-			->legend( 'Contact Details' )
-			->before( '<p style="color:#6b7280;font-size:13px;margin:0 0 8px;">Please fill in your details below.</p>' )
-			->after( '<p style="color:#6b7280;font-size:13px;margin:8px 0 0;">All fields are optional.</p>' )
-			->fields(
-				Text::make( 'company' )->label( 'Company' ),
-				Tel::make( 'phone' )->label( 'Phone' )
-			)
+            ->legend( 'Contact Details' )
+            ->before( '<p style="color:#6b7280;font-size:13px;margin:0 0 8px;">Please fill in your details below.</p>' )
+            ->after( '<p style="color:#6b7280;font-size:13px;margin:8px 0 0;">All fields are optional.</p>' )
+            ->fields(
+                Text::make( 'company' )->label( 'Company' ),
+                Tel::make( 'phone' )->label( 'Phone' )
+            )
 ```
 
 ![before/after](screenshots/fieldset/before-after.png)
@@ -351,13 +351,13 @@ Sets an arbitrary HTML attribute on the fieldset element.
 
 ```php
 Fieldset::make( 'data_fs' )
-			->legend( 'Preferences' )
-			->wrapper_data( 'section', 'preferences' )
-			->add_wrapper_class( 'highlighted-fieldset' )
-			->fields(
-				Text::make( 'language' )->label( 'Language' ),
-				Text::make( 'timezone' )->label( 'Timezone' )
-			)
+            ->legend( 'Preferences' )
+            ->wrapper_data( 'section', 'preferences' )
+            ->add_wrapper_class( 'highlighted-fieldset' )
+            ->fields(
+                Text::make( 'language' )->label( 'Language' ),
+                Text::make( 'timezone' )->label( 'Timezone' )
+            )
 ```
 
 ![wrapper-attrs](screenshots/fieldset/wrapper-attrs.png)

--- a/docs/fields/file.md
+++ b/docs/fields/file.md
@@ -11,9 +11,9 @@ Renders `<input type="file">`. Allows users to select one or more files for uplo
 
 ```php
 $this->component( new Input_Component(
-		File::make( 'upload' )
-			->label( 'Upload File' )
-	) )
+        File::make( 'upload' )
+            ->label( 'Upload File' )
+    ) )
 ```
 
 ![Basic](screenshots/file/basic.png)

--- a/docs/fields/form.md
+++ b/docs/fields/form.md
@@ -12,24 +12,24 @@ Renders a `<form>` element that wraps child field components. Acts as a containe
 
 ```php
 $this->component( new Form_Component(
-		Form::make( 'contact' )
-			->method( 'POST' )
-			->action( '/submit' )
-			->fields(
-				Text::make( 'name' )
-					->label( 'Name' )
-					->required( true ),
-				Email::make( 'email' )
-					->label( 'Email' )
-					->required( true ),
-				Textarea::make( 'message' )
-					->label( 'Message' )
-					->rows( 4 ),
-				Button::make( 'submit' )
-					->type( 'submit' )
-					->text( 'Send' )
-			)
-	) )
+        Form::make( 'contact' )
+            ->method( 'POST' )
+            ->action( '/submit' )
+            ->fields(
+                Text::make( 'name' )
+                    ->label( 'Name' )
+                    ->required( true ),
+                Email::make( 'email' )
+                    ->label( 'Email' )
+                    ->required( true ),
+                Textarea::make( 'message' )
+                    ->label( 'Message' )
+                    ->rows( 4 ),
+                Button::make( 'submit' )
+                    ->type( 'submit' )
+                    ->text( 'Send' )
+            )
+    ) )
 ```
 
 ![Basic](screenshots/form/basic.png)
@@ -88,16 +88,16 @@ Sets the HTTP method for the form. Defaults to `POST`. Automatically uppercased.
 
 ```php
 Form::make( 'search_form' )
-			->method( 'GET' )
-			->action( '/search' )
-			->fields(
-				Text::make( 'query' )
-					->label( 'Search' )
-					->placeholder( 'Search...' ),
-				Button::make( 'go' )
-					->type( 'submit' )
-					->text( 'Go' )
-			)
+            ->method( 'GET' )
+            ->action( '/search' )
+            ->fields(
+                Text::make( 'query' )
+                    ->label( 'Search' )
+                    ->placeholder( 'Search...' ),
+                Button::make( 'go' )
+                    ->type( 'submit' )
+                    ->text( 'Go' )
+            )
 ```
 
 ![get-form](screenshots/form/get-form.png)
@@ -151,16 +151,16 @@ Sets the form encoding type. Required for file uploads.
 
 ```php
 Form::make( 'upload_form' )
-			->method( 'POST' )
-			->action( '/upload' )
-			->enctype( 'multipart/form-data' )
-			->fields(
-				Text::make( 'file_label' )
-					->label( 'File Label' ),
-				Button::make( 'upload' )
-					->type( 'submit' )
-					->text( 'Upload' )
-			)
+            ->method( 'POST' )
+            ->action( '/upload' )
+            ->enctype( 'multipart/form-data' )
+            ->fields(
+                Text::make( 'file_label' )
+                    ->label( 'File Label' ),
+                Button::make( 'upload' )
+                    ->type( 'submit' )
+                    ->text( 'Upload' )
+            )
 ```
 
 ![enctype](screenshots/form/enctype.png)
@@ -187,18 +187,18 @@ Adds child elements (fields, buttons, nonces, fieldsets, raw HTML) to the form. 
 
 ```php
 Form::make( 'secure_form' )
-			->method( 'POST' )
-			->fields(
-				Hidden::make( 'form_id' )
-					->set_existing( '42' )
-					->show_wrapper( false ),
-				Nonce::make( 'save_action', 'form_nonce' ),
-				Text::make( 'title' )
-					->label( 'Title' ),
-				Button::make( 'save' )
-					->type( 'submit' )
-					->text( 'Save' )
-			)
+            ->method( 'POST' )
+            ->fields(
+                Hidden::make( 'form_id' )
+                    ->set_existing( '42' )
+                    ->show_wrapper( false ),
+                Nonce::make( 'save_action', 'form_nonce' ),
+                Text::make( 'title' )
+                    ->label( 'Title' ),
+                Button::make( 'save' )
+                    ->type( 'submit' )
+                    ->text( 'Save' )
+            )
 ```
 
 ![nonce](screenshots/form/nonce.png)
@@ -258,8 +258,8 @@ HTML content before or after the form's child elements, rendered inside the `<fo
 
 ```php
 Form::make( 'wrapped_form' )
-			->method( 'POST' )
-			->before( '<div style="padding:8px 0;color:#374151;font-weight:500;">Contact Us
+            ->method( 'POST' )
+            ->before( '<div style="padding:8px 0;color:#374151;font-weight:500;">Contact Us
 ```
 
 ![before/after](screenshots/form/before-after.png)
@@ -482,28 +482,28 @@ Form::make( 'contact' )
 
 ```php
 Form::make( 'complex_form' )
-			->method( 'POST' )
-			->fields(
-				Raw_HTML::make( 'intro' )
-					->html( '<p style="color:#6b7280;margin:0 0 12px;">Fill in all required fields.</p>' ),
-				Select::make( 'category' )
-					->label( 'Category' )
-					->options( array(
-						''        => 'Select...',
-						'bug'     => 'Bug Report',
-						'feature' => 'Feature Request',
-					) )
-					->required( true ),
-				Text::make( 'subject' )
-					->label( 'Subject' )
-					->required( true ),
-				Textarea::make( 'details' )
-					->label( 'Details' )
-					->rows( 4 ),
-				Button::make( 'submit' )
-					->type( 'submit' )
-					->text( 'Submit' )
-			)
+            ->method( 'POST' )
+            ->fields(
+                Raw_HTML::make( 'intro' )
+                    ->html( '<p style="color:#6b7280;margin:0 0 12px;">Fill in all required fields.</p>' ),
+                Select::make( 'category' )
+                    ->label( 'Category' )
+                    ->options( array(
+                        ''        => 'Select...',
+                        'bug'     => 'Bug Report',
+                        'feature' => 'Feature Request',
+                    ) )
+                    ->required( true ),
+                Text::make( 'subject' )
+                    ->label( 'Subject' )
+                    ->required( true ),
+                Textarea::make( 'details' )
+                    ->label( 'Details' )
+                    ->rows( 4 ),
+                Button::make( 'submit' )
+                    ->type( 'submit' )
+                    ->text( 'Submit' )
+            )
 ```
 
 ![complex](screenshots/form/complex.png)

--- a/docs/fields/hidden.md
+++ b/docs/fields/hidden.md
@@ -13,11 +13,11 @@ Hidden inputs have no visible UI. The wrapper is disabled by default (`show_wrap
 
 ```php
 $this->component( new Input_Component(
-		Hidden::make( 'form_id' )
-			->set_existing( '42' )
-			->show_wrapper( false )
-	) );
-	<p style="color:#6b7280;font-size:13px;">A hidden input is rendered above but not visible. Defaults to show_wrapper(false).</p>
+        Hidden::make( 'form_id' )
+            ->set_existing( '42' )
+            ->show_wrapper( false )
+    ) );
+    <p style="color:#6b7280;font-size:13px;">A hidden input is rendered above but not visible. Defaults to show_wrapper(false).</p>
 ```
 
 ![Basic](screenshots/hidden/basic.png)

--- a/docs/fields/month.md
+++ b/docs/fields/month.md
@@ -11,9 +11,9 @@ Renders `<input type="month">` with a browser-native month/year picker. Values a
 
 ```php
 $this->component( new Input_Component(
-		Month::make( 'birth_month' )
-			->label( 'Birth Month' )
-	) )
+        Month::make( 'birth_month' )
+            ->label( 'Birth Month' )
+    ) )
 ```
 
 ![Basic](screenshots/month/basic.png)
@@ -75,8 +75,8 @@ Sets the current value. Runs through a month format sanitizer (`Y-m`) by default
 
 ```php
 Month::make( 'expiry' )
-			->label( 'Expiry Month' )
-			->set_existing( '2026-06' )
+            ->label( 'Expiry Month' )
+            ->set_existing( '2026-06' )
 ```
 
 ![set_existing](screenshots/month/value.png)
@@ -194,9 +194,9 @@ Disables the input. Value is visible but cannot be changed or submitted.
 
 ```php
 Month::make( 'locked_month' )
-			->label( 'Locked' )
-			->set_existing( '2026-01' )
-			->disabled( true )
+            ->label( 'Locked' )
+            ->set_existing( '2026-01' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/month/disabled.png)
@@ -371,9 +371,9 @@ Displays an error message below the field.
 
 ```php
 Month::make( 'expired_month' )
-			->label( 'Expiry' )
-			->set_existing( '2020-01' )
-			->error_notification( 'This month has expired.' )
+            ->label( 'Expiry' )
+            ->set_existing( '2020-01' )
+            ->error_notification( 'This month has expired.' )
 ```
 
 ![notification](screenshots/month/notification.png)
@@ -492,9 +492,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Month::make( 'wrapped_month' )
-			->label( 'Billing Month' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Select billing period</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Charges applied at month end</span>' )
+            ->label( 'Billing Month' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Select billing period</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Charges applied at month end</span>' )
 ```
 
 ![before/after](screenshots/month/before-after.png)

--- a/docs/fields/number.md
+++ b/docs/fields/number.md
@@ -11,10 +11,10 @@ Renders `<input type="number">` with spinner controls for incrementing/decrement
 
 ```php
 $this->component( new Input_Component(
-		Number::make( 'quantity' )
-			->label( 'Quantity' )
-			->set_existing( '42' )
-	) )
+        Number::make( 'quantity' )
+            ->label( 'Quantity' )
+            ->set_existing( '42' )
+    ) )
 ```
 
 ![Basic](screenshots/number/basic.png)
@@ -100,10 +100,10 @@ Placeholder text shown when the field is empty.
 
 ```php
 Number::make( 'amount' )
-			->label( 'Amount' )
-			->placeholder( '0-1000' )
-			->min( 0 )
-			->max( 1000 )
+            ->label( 'Amount' )
+            ->placeholder( '0-1000' )
+            ->min( 0 )
+            ->max( 1000 )
 ```
 
 ![placeholder](screenshots/number/placeholder.png)
@@ -173,11 +173,11 @@ Sets both min and max in a single call.
 
 ```php
 Number::make( 'age' )
-			->label( 'Age' )
-			->min( 1 )
-			->max( 120 )
-			->step( 1 )
-			->set_existing( '25' )
+            ->label( 'Age' )
+            ->min( 1 )
+            ->max( 120 )
+            ->step( 1 )
+            ->set_existing( '25' )
 ```
 
 ![range](screenshots/number/range.png)
@@ -483,9 +483,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Number::make( 'wrapped_num' )
-			->label( 'Price' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Enter amount in GBP</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Excluding VAT</span>' )
+            ->label( 'Price' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Enter amount in GBP</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Excluding VAT</span>' )
 ```
 
 ![before/after](screenshots/number/before-after.png)

--- a/docs/fields/password.md
+++ b/docs/fields/password.md
@@ -11,10 +11,10 @@ Renders `<input type="password">`. Values are masked with dots in the browser.
 
 ```php
 $this->component( new Input_Component(
-		Password::make( 'password' )
-			->label( 'Password' )
-			->placeholder( 'Enter your password' )
-	) )
+        Password::make( 'password' )
+            ->label( 'Password' )
+            ->placeholder( 'Enter your password' )
+    ) )
 ```
 
 ![Basic](screenshots/password/basic.png)
@@ -74,8 +74,8 @@ Sets the current value. The value is masked in the browser. Runs through the san
 
 ```php
 Password::make( 'current_pw' )
-			->label( 'Current Password' )
-			->set_existing( 'secretpass' )
+            ->label( 'Current Password' )
+            ->set_existing( 'secretpass' )
 ```
 
 ![set_existing](screenshots/password/value.png)
@@ -421,9 +421,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Password::make( 'wrapped_pw' )
-			->label( 'Password' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Must be at least 8 characters</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Include uppercase, lowercase and numbers</span>' )
+            ->label( 'Password' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Must be at least 8 characters</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Include uppercase, lowercase and numbers</span>' )
 ```
 
 ![before/after](screenshots/password/before-after.png)

--- a/docs/fields/radio-group.md
+++ b/docs/fields/radio-group.md
@@ -11,14 +11,14 @@ Renders a group of `<input type="radio">` elements from an options array, allowi
 
 ```php
 $this->component( new Radio_Group_Component(
-		Radio_Group::make( 'size' )
-			->label( 'Size' )
-			->options( array(
-				'small'  => 'Small',
-				'medium' => 'Medium',
-				'large'  => 'Large',
-			) )
-	) )
+        Radio_Group::make( 'size' )
+            ->label( 'Size' )
+            ->options( array(
+                'small'  => 'Small',
+                'medium' => 'Medium',
+                'large'  => 'Large',
+            ) )
+    ) )
 ```
 
 ![Basic](screenshots/radio-group/basic.png)
@@ -120,13 +120,13 @@ Sets which radio button is selected by passing a single value string.
 
 ```php
 Radio_Group::make( 'plan' )
-			->label( 'Plan' )
-			->options( array(
-				'free' => 'Free',
-				'pro'  => 'Professional',
-				'ent'  => 'Enterprise',
-			) )
-			->selected( 'pro' )
+            ->label( 'Plan' )
+            ->options( array(
+                'free' => 'Free',
+                'pro'  => 'Professional',
+                'ent'  => 'Enterprise',
+            ) )
+            ->selected( 'pro' )
 ```
 
 ![selected](screenshots/radio-group/selected.png)
@@ -224,13 +224,13 @@ Disables the entire radio group. Each individual radio button receives the `disa
 
 ```php
 Radio_Group::make( 'locked_choice' )
-			->label( 'Status' )
-			->options( array(
-				'active'   => 'Active',
-				'inactive' => 'Inactive',
-			) )
-			->selected( 'active' )
-			->disabled( true )
+            ->label( 'Status' )
+            ->options( array(
+                'active'   => 'Active',
+                'inactive' => 'Inactive',
+            ) )
+            ->selected( 'active' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/radio-group/disabled.png)
@@ -255,13 +255,13 @@ Displays an error message below the group.
 
 ```php
 Radio_Group::make( 'required_choice' )
-			->label( 'Shipping Method' )
-			->options( array(
-				'standard' => 'Standard (3-5 days)',
-				'express'  => 'Express (1-2 days)',
-				'next_day' => 'Next Day',
-			) )
-			->error_notification( 'Please select a shipping method.' )
+            ->label( 'Shipping Method' )
+            ->options( array(
+                'standard' => 'Standard (3-5 days)',
+                'express'  => 'Express (1-2 days)',
+                'next_day' => 'Next Day',
+            ) )
+            ->error_notification( 'Please select a shipping method.' )
 ```
 
 ![notification](screenshots/radio-group/notification.png)
@@ -400,14 +400,14 @@ HTML content before or after the radio group; renders whether or not the wrapper
 
 ```php
 Radio_Group::make( 'payment' )
-			->label( 'Payment Method' )
-			->options( array(
-				'card'   => 'Credit Card',
-				'paypal' => 'PayPal',
-				'bank'   => 'Bank Transfer',
-			) )
-			->before( '<span style="color:#6b7280;font-size:13px;">Select payment method:</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">All payments are processed securely.</span>' )
+            ->label( 'Payment Method' )
+            ->options( array(
+                'card'   => 'Credit Card',
+                'paypal' => 'PayPal',
+                'bank'   => 'Bank Transfer',
+            ) )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Select payment method:</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">All payments are processed securely.</span>' )
 ```
 
 ![before/after](screenshots/radio-group/before-after.png)

--- a/docs/fields/radio.md
+++ b/docs/fields/radio.md
@@ -11,10 +11,10 @@ Renders `<input type="radio">`. A single radio button, typically used within a g
 
 ```php
 $this->component( new Input_Component(
-		Radio::make( 'option_a' )
-			->label( 'Option A' )
-			->value( 'a' )
-	) )
+        Radio::make( 'option_a' )
+            ->label( 'Option A' )
+            ->value( 'a' )
+    ) )
 ```
 
 ![Basic](screenshots/radio/unchecked.png)
@@ -123,9 +123,9 @@ Sets whether the radio button is in a selected state.
 
 ```php
 Radio::make( 'option_b' )
-			->label( 'Option B' )
-			->value( 'b' )
-			->checked( true )
+            ->label( 'Option B' )
+            ->value( 'b' )
+            ->checked( true )
 ```
 
 ![checked](screenshots/radio/checked.png)
@@ -172,10 +172,10 @@ Disables the radio button. It is visible but cannot be selected or submitted.
 
 ```php
 Radio::make( 'locked_option' )
-			->label( 'Locked Option' )
-			->value( 'locked' )
-			->checked( true )
-			->disabled( true )
+            ->label( 'Locked Option' )
+            ->value( 'locked' )
+            ->checked( true )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/radio/disabled.png)
@@ -197,9 +197,9 @@ Displays an error message below the field.
 
 ```php
 Radio::make( 'required_radio' )
-			->label( 'Choose this option' )
-			->value( 'choice' )
-			->error_notification( 'You must select an option.' )
+            ->label( 'Choose this option' )
+            ->value( 'choice' )
+            ->error_notification( 'You must select an option.' )
 ```
 
 ![error_notification](screenshots/radio/notification.png)

--- a/docs/fields/range.md
+++ b/docs/fields/range.md
@@ -11,12 +11,12 @@ Renders `<input type="range">` as a slider control. Uses a numeric sanitizer by 
 
 ```php
 $this->component( new Input_Component(
-		Range::make( 'volume' )
-			->label( 'Volume' )
-			->min( 0 )
-			->max( 100 )
-			->set_existing( '50' )
-	) )
+        Range::make( 'volume' )
+            ->label( 'Volume' )
+            ->min( 0 )
+            ->max( 100 )
+            ->set_existing( '50' )
+    ) )
 ```
 
 ![Basic](screenshots/range/basic.png)
@@ -176,11 +176,11 @@ Sets the step increment for the slider.
 
 ```php
 Range::make( 'brightness' )
-			->label( 'Brightness' )
-			->min( 0 )
-			->max( 100 )
-			->step( 10 )
-			->set_existing( '70' )
+            ->label( 'Brightness' )
+            ->min( 0 )
+            ->max( 100 )
+            ->step( 10 )
+            ->set_existing( '70' )
 ```
 
 ![step](screenshots/range/step.png)
@@ -439,12 +439,12 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Range::make( 'labeled_range' )
-			->label( 'Opacity' )
-			->min( 0 )
-			->max( 100 )
-			->set_existing( '75' )
-			->before( '<span style="color:#6b7280;font-size:13px;">0%</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">100%</span>' )
+            ->label( 'Opacity' )
+            ->min( 0 )
+            ->max( 100 )
+            ->set_existing( '75' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">0%</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">100%</span>' )
 ```
 
 ![before/after](screenshots/range/before-after.png)

--- a/docs/fields/search.md
+++ b/docs/fields/search.md
@@ -11,10 +11,10 @@ Renders `<input type="search">`. A text input styled for search queries, with br
 
 ```php
 $this->component( new Input_Component(
-		Search::make( 'search' )
-			->label( 'Search' )
-			->placeholder( 'Search...' )
-	) )
+        Search::make( 'search' )
+            ->label( 'Search' )
+            ->placeholder( 'Search...' )
+    ) )
 ```
 
 ![Basic](screenshots/search/basic.png)
@@ -519,9 +519,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Search::make( 'wrapped_search' )
-			->label( 'Search' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Search the documentation</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Use quotes for exact match</span>' )
+            ->label( 'Search' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Search the documentation</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Use quotes for exact match</span>' )
 ```
 
 ![before/after](screenshots/search/before-after.png)

--- a/docs/fields/select.md
+++ b/docs/fields/select.md
@@ -11,16 +11,16 @@ Renders a `<select>` dropdown with options and optional optgroups.
 
 ```php
 $this->component( new Select_Component(
-		Select::make( 'country' )
-			->label( 'Country' )
-			->options( array(
-				''   => '-- Select --',
-				'uk' => 'United Kingdom',
-				'us' => 'United States',
-				'ca' => 'Canada',
-				'au' => 'Australia',
-			) )
-	) )
+        Select::make( 'country' )
+            ->label( 'Country' )
+            ->options( array(
+                ''   => '-- Select --',
+                'uk' => 'United Kingdom',
+                'us' => 'United States',
+                'ca' => 'Canada',
+                'au' => 'Australia',
+            ) )
+    ) )
 ```
 
 ![Basic](screenshots/select/basic.png)
@@ -122,14 +122,14 @@ Sets the current value. Runs through the sanitizer if one is set. When `multiple
 
 ```php
 Select::make( 'role' )
-			->label( 'Role' )
-			->options( array(
-				'admin'      => 'Administrator',
-				'editor'     => 'Editor',
-				'author'     => 'Author',
-				'subscriber' => 'Subscriber',
-			) )
-			->set_existing( 'editor' )
+            ->label( 'Role' )
+            ->options( array(
+                'admin'      => 'Administrator',
+                'editor'     => 'Editor',
+                'author'     => 'Author',
+                'subscriber' => 'Subscriber',
+            ) )
+            ->set_existing( 'editor' )
 ```
 
 ![selected](screenshots/select/selected.png)
@@ -207,16 +207,16 @@ Adds an optgroup with its own set of options. Can be called multiple times to ad
 
 ```php
 Select::make( 'vehicle' )
-			->label( 'Vehicle' )
-			->optgroup( 'Cars', array(
-				'volvo' => 'Volvo',
-				'bmw'   => 'BMW',
-				'audi'  => 'Audi',
-			) )
-			->optgroup( 'Bikes', array(
-				'honda'  => 'Honda',
-				'yamaha' => 'Yamaha',
-			) )
+            ->label( 'Vehicle' )
+            ->optgroup( 'Cars', array(
+                'volvo' => 'Volvo',
+                'bmw'   => 'BMW',
+                'audi'  => 'Audi',
+            ) )
+            ->optgroup( 'Bikes', array(
+                'honda'  => 'Honda',
+                'yamaha' => 'Yamaha',
+            ) )
 ```
 
 ![optgroups](screenshots/select/optgroups.png)
@@ -248,17 +248,17 @@ Enables multi-select. When enabled, the `name` attribute gets a `[]` suffix and 
 
 ```php
 Select::make( 'languages' )
-			->label( 'Languages' )
-			->options( array(
-				'php'    => 'PHP',
-				'js'     => 'JavaScript',
-				'python' => 'Python',
-				'go'     => 'Go',
-				'rust'   => 'Rust',
-			) )
-			->multiple( true )
-			->size( 5 )
-			->set_existing( array( 'php', 'go' ) )
+            ->label( 'Languages' )
+            ->options( array(
+                'php'    => 'PHP',
+                'js'     => 'JavaScript',
+                'python' => 'Python',
+                'go'     => 'Go',
+                'rust'   => 'Rust',
+            ) )
+            ->multiple( true )
+            ->size( 5 )
+            ->set_existing( array( 'php', 'go' ) )
 ```
 
 ![multiple](screenshots/select/multiple.png)
@@ -286,15 +286,15 @@ Sets the number of visible rows in the dropdown (useful with `multiple()`).
 
 ```php
 Select::make( 'visible_list' )
-			->label( 'Items (3 visible)' )
-			->options( array(
-				'a' => 'Alpha',
-				'b' => 'Bravo',
-				'c' => 'Charlie',
-				'd' => 'Delta',
-				'e' => 'Echo',
-			) )
-			->size( 3 )
+            ->label( 'Items (3 visible)' )
+            ->options( array(
+                'a' => 'Alpha',
+                'b' => 'Bravo',
+                'c' => 'Charlie',
+                'd' => 'Delta',
+                'e' => 'Echo',
+            ) )
+            ->size( 3 )
 ```
 
 ![size](screenshots/select/size.png)
@@ -350,10 +350,10 @@ Disables the select. Value is visible but cannot be changed or submitted.
 
 ```php
 Select::make( 'locked_plan' )
-			->label( 'Plan' )
-			->options( array( 'pro' => 'Professional' ) )
-			->set_existing( 'pro' )
-			->disabled( true )
+            ->label( 'Plan' )
+            ->options( array( 'pro' => 'Professional' ) )
+            ->set_existing( 'pro' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/select/disabled.png)
@@ -441,9 +441,9 @@ Displays an error message below the field.
 
 ```php
 Select::make( 'bad_select' )
-			->label( 'Category' )
-			->options( array( '' => 'Select...', 'bug' => 'Bug', 'feature' => 'Feature' ) )
-			->error_notification( 'Please select a category.' )
+            ->label( 'Category' )
+            ->options( array( '' => 'Select...', 'bug' => 'Bug', 'feature' => 'Feature' ) )
+            ->error_notification( 'Please select a category.' )
 ```
 
 ![notification](screenshots/select/notification.png)

--- a/docs/fields/tel.md
+++ b/docs/fields/tel.md
@@ -11,10 +11,10 @@ Renders `<input type="tel">`. On mobile devices, the browser shows a telephone k
 
 ```php
 $this->component( new Input_Component(
-		Tel::make( 'phone' )
-			->label( 'Phone Number' )
-			->placeholder( '+44 7700 900000' )
-	) )
+        Tel::make( 'phone' )
+            ->label( 'Phone Number' )
+            ->placeholder( '+44 7700 900000' )
+    ) )
 ```
 
 ![Basic](screenshots/tel/basic.png)
@@ -537,9 +537,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Tel::make( 'wrapped_tel' )
-			->label( 'Phone' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Include country code</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">e.g. +44 7700 900000</span>' )
+            ->label( 'Phone' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Include country code</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">e.g. +44 7700 900000</span>' )
 ```
 
 ![before/after](screenshots/tel/before-after.png)

--- a/docs/fields/text.md
+++ b/docs/fields/text.md
@@ -11,9 +11,9 @@ Renders `<input type="text">`. The most common input type with the widest range 
 
 ```php
 $this->component( new Input_Component(
-		Text::make( 'username' )
-			->label( 'Username' )
-	) )
+        Text::make( 'username' )
+            ->label( 'Username' )
+    ) )
 ```
 
 ![Basic](screenshots/text/basic.png)
@@ -60,8 +60,8 @@ Sets the current value. Runs through the sanitizer if one is set.
 
 ```php
 Text::make( 'fullname' )
-			->label( 'Full Name' )
-			->set_existing( 'John Smith' )
+            ->label( 'Full Name' )
+            ->set_existing( 'John Smith' )
 ```
 
 ![set_existing](screenshots/text/value.png)
@@ -83,8 +83,8 @@ Placeholder text shown when the field is empty.
 
 ```php
 Text::make( 'search_query' )
-			->label( 'Search' )
-			->placeholder( 'Type to search...' )
+            ->label( 'Search' )
+            ->placeholder( 'Type to search...' )
 ```
 
 ![placeholder](screenshots/text/placeholder.png)
@@ -106,8 +106,8 @@ Marks the field as required. The label displays a `*` indicator via CSS.
 
 ```php
 Text::make( 'email_addr' )
-			->label( 'Email Address' )
-			->required( true )
+            ->label( 'Email Address' )
+            ->required( true )
 ```
 
 ![required](screenshots/text/required.png)
@@ -129,9 +129,9 @@ Disables the input. Value is visible but cannot be changed or submitted.
 
 ```php
 Text::make( 'locked_field' )
-			->label( 'Locked Field' )
-			->set_existing( 'Cannot edit' )
-			->disabled( true )
+            ->label( 'Locked Field' )
+            ->set_existing( 'Cannot edit' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/text/disabled.png)
@@ -372,9 +372,9 @@ Autocomplete suggestions via an HTML `<datalist>` element.
 
 ```php
 Text::make( 'fruit' )
-			->label( 'Favourite Fruit' )
-			->datalist_items( array( 'Apple', 'Banana', 'Cherry', 'Date', 'Elderberry' ) )
-			->placeholder( 'Start typing...' )
+            ->label( 'Favourite Fruit' )
+            ->datalist_items( array( 'Apple', 'Banana', 'Cherry', 'Date', 'Elderberry' ) )
+            ->placeholder( 'Start typing...' )
 ```
 
 ![datalist](screenshots/text/datalist.png)
@@ -408,9 +408,9 @@ Displays an error message below the field.
 
 ```php
 Text::make( 'name_error' )
-			->label( 'Name' )
-			->required( true )
-			->error_notification( 'This field is required.' )
+            ->label( 'Name' )
+            ->required( true )
+            ->error_notification( 'This field is required.' )
 ```
 
 ![error_notification](screenshots/text/notification-error.png)
@@ -433,9 +433,9 @@ Displays a warning message below the field.
 
 ```php
 Text::make( 'name_warning' )
-			->label( 'Display Name' )
-			->set_existing( 'ab' )
-			->warning_notification( 'Name is very short.' )
+            ->label( 'Display Name' )
+            ->set_existing( 'ab' )
+            ->warning_notification( 'Name is very short.' )
 ```
 
 ![warning_notification](screenshots/text/notification-warning.png)
@@ -458,9 +458,9 @@ Displays a success message below the field.
 
 ```php
 Text::make( 'name_success' )
-			->label( 'Username' )
-			->set_existing( 'johndoe' )
-			->success_notification( 'Username is available!' )
+            ->label( 'Username' )
+            ->set_existing( 'johndoe' )
+            ->success_notification( 'Username is available!' )
 ```
 
 ![success_notification](screenshots/text/notification-success.png)
@@ -483,8 +483,8 @@ Displays an info message below the field.
 
 ```php
 Text::make( 'name_info' )
-			->label( 'Slug' )
-			->info_notification( 'Only lowercase letters and hyphens.' )
+            ->label( 'Slug' )
+            ->info_notification( 'Only lowercase letters and hyphens.' )
 ```
 
 ![info_notification](screenshots/text/notification-info.png)
@@ -527,9 +527,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Text::make( 'wrapped_field' )
-			->label( 'Amount' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Enter the amount below</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Amount in GBP</span>' )
+            ->label( 'Amount' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Enter the amount below</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Amount in GBP</span>' )
 ```
 
 ![before/after](screenshots/text/before-after.png)

--- a/docs/fields/textarea.md
+++ b/docs/fields/textarea.md
@@ -11,10 +11,10 @@ Renders a `<textarea>` element for multi-line text input.
 
 ```php
 $this->component( new Textarea_Component(
-		Textarea::make( 'message' )
-			->label( 'Message' )
-			->rows( 4 )
-	) )
+        Textarea::make( 'message' )
+            ->label( 'Message' )
+            ->rows( 4 )
+    ) )
 ```
 
 ![Basic](screenshots/textarea/basic.png)
@@ -76,9 +76,9 @@ Sets the current value. Runs through the sanitizer if one is set.
 
 ```php
 Textarea::make( 'bio' )
-			->label( 'Bio' )
-			->set_existing( 'A software developer with a passion for clean code and good documentation.' )
-			->rows( 3 )
+            ->label( 'Bio' )
+            ->set_existing( 'A software developer with a passion for clean code and good documentation.' )
+            ->rows( 3 )
 ```
 
 ![value](screenshots/textarea/value.png)
@@ -100,9 +100,9 @@ Placeholder text shown when the textarea is empty.
 
 ```php
 Textarea::make( 'notes' )
-			->label( 'Notes' )
-			->placeholder( 'Enter your notes here...' )
-			->rows( 3 )
+            ->label( 'Notes' )
+            ->placeholder( 'Enter your notes here...' )
+            ->rows( 3 )
 ```
 
 ![placeholder](screenshots/textarea/placeholder.png)
@@ -197,10 +197,10 @@ Disables the textarea. Value is visible but cannot be changed or submitted.
 
 ```php
 Textarea::make( 'disabled_ta' )
-			->label( 'Disabled' )
-			->set_existing( 'This textarea is disabled.' )
-			->disabled( true )
-			->rows( 2 )
+            ->label( 'Disabled' )
+            ->set_existing( 'This textarea is disabled.' )
+            ->disabled( true )
+            ->rows( 2 )
 ```
 
 ![disabled](screenshots/textarea/disabled.png)
@@ -356,10 +356,10 @@ Displays an error message below the field.
 
 ```php
 Textarea::make( 'short_msg' )
-			->label( 'Message' )
-			->set_existing( 'Hi' )
-			->error_notification( 'Message must be at least 10 characters.' )
-			->rows( 3 )
+            ->label( 'Message' )
+            ->set_existing( 'Hi' )
+            ->error_notification( 'Message must be at least 10 characters.' )
+            ->rows( 3 )
 ```
 
 ![notification](screenshots/textarea/notification.png)

--- a/docs/fields/time.md
+++ b/docs/fields/time.md
@@ -11,9 +11,9 @@ Renders `<input type="time">` with a browser-native time picker. Values are form
 
 ```php
 $this->component( new Input_Component(
-		Time::make( 'meeting_time' )
-			->label( 'Meeting Time' )
-	) )
+        Time::make( 'meeting_time' )
+            ->label( 'Meeting Time' )
+    ) )
 ```
 
 ![Basic](screenshots/time/basic.png)
@@ -75,8 +75,8 @@ Sets the current value. Runs through a time format sanitizer (`H:i:s`) by defaul
 
 ```php
 Time::make( 'start_time' )
-			->label( 'Start Time' )
-			->set_existing( '14:30' )
+            ->label( 'Start Time' )
+            ->set_existing( '14:30' )
 ```
 
 ![set_existing](screenshots/time/value.png)
@@ -290,9 +290,9 @@ Disables the input. Value is visible but cannot be changed or submitted.
 
 ```php
 Time::make( 'locked_time' )
-			->label( 'Locked Time' )
-			->set_existing( '09:00' )
-			->disabled( true )
+            ->label( 'Locked Time' )
+            ->set_existing( '09:00' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/time/disabled.png)
@@ -468,8 +468,8 @@ Displays an error message below the field.
 
 ```php
 Time::make( 'notif_time' )
-			->label( 'Time' )
-			->info_notification( 'Business hours: 09:00 - 17:00' )
+            ->label( 'Time' )
+            ->info_notification( 'Business hours: 09:00 - 17:00' )
 ```
 
 ![notification](screenshots/time/notification.png)
@@ -588,9 +588,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Time::make( 'wrapped_time' )
-			->label( 'Appointment' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Select appointment time</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Times shown in GMT</span>' )
+            ->label( 'Appointment' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Select appointment time</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Times shown in GMT</span>' )
 ```
 
 ![before/after](screenshots/time/before-after.png)

--- a/docs/fields/url.md
+++ b/docs/fields/url.md
@@ -11,10 +11,10 @@ Renders `<input type="url">`. The browser provides built-in URL format validatio
 
 ```php
 $this->component( new Input_Component(
-		Url::make( 'website' )
-			->label( 'Website' )
-			->placeholder( 'https://example.com' )
-	) )
+        Url::make( 'website' )
+            ->label( 'Website' )
+            ->placeholder( 'https://example.com' )
+    ) )
 ```
 
 ![Basic](screenshots/url/basic.png)
@@ -541,9 +541,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Url::make( 'wrapped_url' )
-			->label( 'Website' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Your public profile URL</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Must start with https://</span>' )
+            ->label( 'Website' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Your public profile URL</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Must start with https://</span>' )
 ```
 
 ![before/after](screenshots/url/before-after.png)

--- a/docs/fields/week.md
+++ b/docs/fields/week.md
@@ -11,9 +11,9 @@ Renders `<input type="week">` with a browser-native week/year picker. Values are
 
 ```php
 $this->component( new Input_Component(
-		Week::make( 'report_week' )
-			->label( 'Report Week' )
-	) )
+        Week::make( 'report_week' )
+            ->label( 'Report Week' )
+    ) )
 ```
 
 ![Basic](screenshots/week/basic.png)
@@ -75,8 +75,8 @@ Sets the current value. Runs through a week format sanitizer (`Y-\WW`) by defaul
 
 ```php
 Week::make( 'current_week' )
-			->label( 'Current Week' )
-			->set_existing( '2026-W14' )
+            ->label( 'Current Week' )
+            ->set_existing( '2026-W14' )
 ```
 
 ![set_existing](screenshots/week/value.png)
@@ -194,9 +194,9 @@ Disables the input. Value is visible but cannot be changed or submitted.
 
 ```php
 Week::make( 'locked_week' )
-			->label( 'Locked' )
-			->set_existing( '2026-W01' )
-			->disabled( true )
+            ->label( 'Locked' )
+            ->set_existing( '2026-W01' )
+            ->disabled( true )
 ```
 
 ![disabled](screenshots/week/disabled.png)
@@ -371,9 +371,9 @@ Displays an error message below the field.
 
 ```php
 Week::make( 'notif_week' )
-			->label( 'Week' )
-			->set_existing( '2026-W52' )
-			->warning_notification( 'This is a holiday week.' )
+            ->label( 'Week' )
+            ->set_existing( '2026-W52' )
+            ->warning_notification( 'This is a holiday week.' )
 ```
 
 ![notification](screenshots/week/notification.png)
@@ -492,9 +492,9 @@ HTML content before or after the input; renders whether or not the wrapper is sh
 
 ```php
 Week::make( 'wrapped_week' )
-			->label( 'Sprint Week' )
-			->before( '<span style="color:#6b7280;font-size:13px;">Select sprint period</span>' )
-			->after( '<span style="color:#6b7280;font-size:13px;">Sprints run Monday to Friday</span>' )
+            ->label( 'Sprint Week' )
+            ->before( '<span style="color:#6b7280;font-size:13px;">Select sprint period</span>' )
+            ->after( '<span style="color:#6b7280;font-size:13px;">Sprints run Monday to Friday</span>' )
 ```
 
 ![before/after](screenshots/week/before-after.png)


### PR DESCRIPTION
Every fenced code block in docs/fields/*.md was tab-indented (copy- pasted from PHP source). The docs site (Jekyll + Just-the-Docs) renders tabs at the browser default 8-column tab-stop, making nested PHP look broken next to other blocks that already used 4 spaces. See the issue #23 fix discussion for the visible symptom.

Source PHP keeps tabs (project/WP convention). This is a docs-only normalisation across all 25 field doc pages.

git diff -w shows zero changes (no semantic edits).